### PR TITLE
changed default MD5 to SHA1 checksums

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddBagToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddBagToDeposit.scala
@@ -22,6 +22,7 @@ import gov.loc.repository.bagit.BagFactory.Version
 import gov.loc.repository.bagit.Manifest.Algorithm
 import gov.loc.repository.bagit.utilities.MessageDigestHelper
 import gov.loc.repository.bagit.writer.impl.FileSystemWriter
+import gov.loc.repository.bagit.transformer.impl.DefaultCompleter
 import nl.knaw.dans.easy.multideposit._
 import nl.knaw.dans.easy.multideposit.actions.AddBagToDeposit._
 import org.slf4j.LoggerFactory
@@ -60,14 +61,19 @@ object AddBagToDeposit {
       if (!inputDirExists) fsw.setTagFilesOnly(true)
       fsw.write(bag, outputBagDir)
 
+      val algorithm = Algorithm.SHA1
+      val completer = new DefaultCompleter(bagFactory)
+      completer.setTagManifestAlgorithm(algorithm)
+      completer.setPayloadManifestAlgorithm(algorithm)
+
       if (!inputDirExists) preBag.setIgnoreAdditionalDirectories(List(metadataDirName))
-      preBag.makeBagInPlace(Version.V0_97, false)
+      preBag.makeBagInPlace(Version.V0_97, false, completer)
 
       // TODO, this is temporary, waiting for response from the BagIt-Java developers.
       if (!inputDirExists) {
         new File(outputBagDir, "data").mkdir()
-        new File(outputBagDir, "manifest-md5.txt").write("")
-        new File(outputBagDir, "tagmanifest-md5.txt").append(s"${MessageDigestHelper.generateFixity(new FileInputStream(new File(outputBagDir, "manifest-md5.txt")), Algorithm.MD5)}  manifest-md5.txt")
+        new File(outputBagDir, "manifest-sha1.txt").write("")
+        new File(outputBagDir, "tagmanifest-sha1.txt").append(s"${MessageDigestHelper.generateFixity(new FileInputStream(new File(outputBagDir, "manifest-sha1.txt")), Algorithm.SHA1)}  manifest-sha1.txt")
       }
     }
   }

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddBagToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddBagToDepositSpec.scala
@@ -79,8 +79,8 @@ class AddBagToDepositSpec extends UnitSpec with BeforeAndAfter with BeforeAndAft
         "file2.txt",
         "file3.txt",
         "file4.txt",
-        "manifest-md5.txt",
-        "tagmanifest-md5.txt")
+        "manifest-sha1.txt",
+        "tagmanifest-sha1.txt")
     outputDepositBagDataDir(settings, datasetID) should exist
   }
 
@@ -114,13 +114,13 @@ class AddBagToDepositSpec extends UnitSpec with BeforeAndAfter with BeforeAndAft
     outputDepositBagDir(settings, datasetID).listRecursively.map(_.getName) should contain theSameElementsAs
       List("bag-info.txt",
         "bagit.txt",
-        "manifest-md5.txt",
-        "tagmanifest-md5.txt")
+        "manifest-sha1.txt",
+        "tagmanifest-sha1.txt")
 
     val root = outputDepositBagDir(settings, datasetID)
-    new File(root, "manifest-md5.txt").read() shouldBe empty
-    new File(root, "tagmanifest-md5.txt").read() should include ("bag-info.txt")
-    new File(root, "tagmanifest-md5.txt").read() should include ("bagit.txt")
-    new File(root, "tagmanifest-md5.txt").read() should include ("manifest-md5.txt")
+    new File(root, "manifest-sha1.txt").read() shouldBe empty
+    new File(root, "tagmanifest-sha1.txt").read() should include ("bag-info.txt")
+    new File(root, "tagmanifest-sha1.txt").read() should include ("bagit.txt")
+    new File(root, "tagmanifest-sha1.txt").read() should include ("manifest-sha1.txt")
   }
 }


### PR DESCRIPTION
fixes EASY-1064
#### When applied it will

Use SHA1 checksums instead of the default MD5
#### Where should the reviewer @DANS-KNAW/easy start?

AddBagToDeposit.createBag
#### How should this be manually tested?

Create a Bag, then check that the bagit files have 'sha1' in their names and not 'md5'. 
Also check the 'tagmanifest-sha1.txt' file, it should contain the SHA1 checksums. 
You could calculate the SHA1 checksum of a data file with another tool and then compare the results, which should be the same. 
