### PR TITLE
(EASY-1107) Map organization-contributors to the right DDM tags

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -112,11 +112,18 @@ object AddDatasetMetadataToDeposit {
 
   def createContributors(dataset: Dataset) = {
     dataset.rowsWithValuesFor(composedContributorFields).map(mdKeyValues =>
-      <dcx-dai:contributorDetails>
+      <dcx-dai:contributorDetails>{
+        if (isOrganization(mdKeyValues))
+        <dcx-dai:organization>
+          <dcx-dai:name xml:lang="en">
+            {mdKeyValues.find(field => organizationKeys.contains(field._1)).map(_._2).getOrElse("")}
+          </dcx-dai:name>
+        </dcx-dai:organization>
+      else
         <dcx-dai:author>
           {mdKeyValues.map(composedEntry(composedContributorFields))}
         </dcx-dai:author>
-      </dcx-dai:contributorDetails>
+      }</dcx-dai:contributorDetails>
     )
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -115,9 +115,7 @@ object AddDatasetMetadataToDeposit {
       <dcx-dai:contributorDetails>{
         if (isOrganization(mdKeyValues))
         <dcx-dai:organization>
-          <dcx-dai:name xml:lang="en">
-            {mdKeyValues.find(field => organizationKeys.contains(field._1)).map(_._2).getOrElse("")}
-          </dcx-dai:name>
+          <dcx-dai:name xml:lang="en">{mdKeyValues.find(field => organizationKeys.contains(field._1)).map(_._2).getOrElse("")}</dcx-dai:name>
         </dcx-dai:organization>
       else
         <dcx-dai:author>

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
@@ -191,7 +191,7 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
       <ddm:dcmiMetadata>
         <dcx-dai:contributorDetails>
           <dcx-dai:organization>
-            <dcx-dai:name xml:lang="en"> some org </dcx-dai:name>
+            <dcx-dai:name xml:lang="en">some org</dcx-dai:name>
           </dcx-dai:organization>
         </dcx-dai:contributorDetails>
       </ddm:dcmiMetadata>

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
@@ -179,6 +179,25 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
     verify(<ddm>{AddDatasetMetadataToDeposit.createMetadata(dataset)}</ddm>,expectedXml)
   }
 
+  it should "have a organization-contributor when no other author-details are given" in {
+    val dataset = new Dataset() +=
+      "DCX_CONTRIBUTOR_TITLES" -> List("", "", "", "") +=
+      "DCX_CONTRIBUTOR_INITIALS" -> List("", "", "", "") +=
+      "DCX_CONTRIBUTOR_INSERTIONS" -> List("", "", "", "") +=
+      "DCX_CONTRIBUTOR_SURNAME" -> List("", "", "", "") +=
+      "DCX_CONTRIBUTOR_DAI" -> List("", "", "", "") +=
+      "DCX_CONTRIBUTOR_ORGANIZATION" -> List("some org", "", "", "")
+    val expectedXml = <ddm>
+      <ddm:dcmiMetadata>
+        <dcx-dai:contributorDetails>
+          <dcx-dai:organization>
+            <dcx-dai:name xml:lang="en"> some org </dcx-dai:name>
+          </dcx-dai:organization>
+        </dcx-dai:contributorDetails>
+      </ddm:dcmiMetadata>
+    </ddm>
+    verify(<ddm>{AddDatasetMetadataToDeposit.createMetadata(dataset)}</ddm>,expectedXml)
+  }
   it should "return the expected contributor" in {
     val dataset = new Dataset() +=
       "DCX_CONTRIBUTOR_TITLES" -> List("", "", "", "") +=


### PR DESCRIPTION
fixes EASY-1107
#### When applied it will
- Map organization-contributors to the right DDM tags
#### Where should the reviewer @DANS-KNAW/easy start?

it's almost equal to createCreators, except for the composedCreatorFields which is now a composedContributorFields
