### PR TITLE
Upgrade scallop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.11</artifactId>
+            <version>2.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>


### PR DESCRIPTION
fixes EASY-1049 Upgrade scallop
#### When applied it will
- use the version 2.0.2 of scallop
#### Where should the reviewer @DANS-KNAW/easy start?

ScallopCommandLine pom
#### How should this be manually tested?
- execute ./run.sh --help (provide first the app.home, see https://github.com/DANS-KNAW/easy-dtap#running-a-new-component)
#### related pull requests on github

| repo | PR |
| --- | --- |
| easy- | [PR#](PRlink) |
