### PR TITLE
Easy-1134: Split the path to the datafile correctly

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
@@ -49,13 +49,13 @@ object AddFileMetadataToDeposit {
 
     <files xmlns:dcterms="http://purl.org/dc/terms/">{
       if (inputDir.exists && inputDir.isDirectory)
-        inputDir.listRecursively.map(xmlPerPath(datasetID))
+        inputDir.listRecursively.map(xmlPerPath(inputDir))
     }</files>
   }
 
   // TODO other fields need to be added here later
-  def xmlPerPath(datasetID: DatasetID)(file: File) = {
-    <file filepath={s"data${file.getAbsolutePath.split(datasetID).last}"}>{
+  def xmlPerPath(inputDir: File)(file: File) = {
+    <file filepath={s"data/${inputDir.toPath.relativize(file.toPath)}"}>{
       <dcterms:format>{getMimeType(file.getPath)}</dcterms:format>
     }</file>
   }

--- a/src/test/resources/spacetravel/ruimtereis01/ruimtereis01_verklaring.txt
+++ b/src/test/resources/spacetravel/ruimtereis01/ruimtereis01_verklaring.txt
@@ -1,0 +1,1 @@
+verklaring van goed gedrag

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
@@ -54,8 +54,9 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with Bef
 
   "datasetToFileXml" should "produce the xml for all the files" in {
     val xml = AddFileMetadataToDeposit.datasetToFileXml("ruimtereis01")
-    xml.child.length shouldBe 4
+    xml.child.length shouldBe 5
 
+    xml.child should contain(<file filepath="data/ruimtereis01_verklaring.txt"><dcterms:format>text/plain</dcterms:format></file>)
     xml.child should contain(<file filepath="data/reisverslag/deel01.docx"><dcterms:format>application/vnd.openxmlformats-officedocument.wordprocessingml.document</dcterms:format></file>)
     xml.child should contain(<file filepath="data/reisverslag/deel01.txt"><dcterms:format>text/plain</dcterms:format></file>)
     xml.child should contain(<file filepath="data/reisverslag/deel02.txt"><dcterms:format>text/plain</dcterms:format></file>)
@@ -63,8 +64,18 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with Bef
   }
 
   //file does not need to exist for the mimetype to be established. it is based solely on filename.
-  "xmlPerPath" should "produce the correct doc mimetype " in {
-    val xml = AddFileMetadataToDeposit.xmlPerPath(datasetID)(new File(multiDepositDir(settings, datasetID), "reisverslag/deel01.doc"))
+  "xmlPerPath" should "create the correct filepath " in {
+    val xml = AddFileMetadataToDeposit.xmlPerPath(multiDepositDir(settings, datasetID))(new File(multiDepositDir(settings, datasetID), "ruimtereis01_verklaring.txt"))
+    val res = <file filepath="data/ruimtereis01_verklaring.txt">
+      <dcterms:format>text/plain</dcterms:format>
+    </file>
+
+    new PrettyPrinter(160, 2).format(xml) shouldBe new PrettyPrinter(160, 2).format(res)
+  }
+
+  //file does not need to exist for the mimetype to be established. it is based solely on filename.
+  it should "produce the correct doc mimetype " in {
+    val xml = AddFileMetadataToDeposit.xmlPerPath(multiDepositDir(settings, datasetID))(new File(multiDepositDir(settings, datasetID), "reisverslag/deel01.doc"))
     val res = <file filepath="data/reisverslag/deel01.doc">
       <dcterms:format>application/msword</dcterms:format>
     </file>
@@ -73,8 +84,8 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with Bef
   }
 
   //file does not need to exist for the mimetype to be established. it is based solely on filename.
-  "xmlPerPath" should "produce the correct docx mimetype " in {
-    val xml = AddFileMetadataToDeposit.xmlPerPath(datasetID)(new File(multiDepositDir(settings, datasetID), "reisverslag/deel01.docx"))
+  it should "produce the correct docx mimetype " in {
+    val xml = AddFileMetadataToDeposit.xmlPerPath(multiDepositDir(settings, datasetID))(new File(multiDepositDir(settings, datasetID), "reisverslag/deel01.docx"))
     val res = <file filepath="data/reisverslag/deel01.docx">
       <dcterms:format>application/vnd.openxmlformats-officedocument.wordprocessingml.document</dcterms:format>
     </file>
@@ -82,8 +93,8 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with Bef
     new PrettyPrinter(160, 2).format(xml) shouldBe new PrettyPrinter(160, 2).format(res)
   }
 
-  "xmlPerPath" should "produce the xml for one file" in {
-    val xml = AddFileMetadataToDeposit.xmlPerPath(datasetID)(new File(multiDepositDir(settings, datasetID), "reisverslag/deel01.txt"))
+  it should "produce the xml for one file" in {
+    val xml = AddFileMetadataToDeposit.xmlPerPath(multiDepositDir(settings, datasetID))(new File(multiDepositDir(settings, datasetID), "reisverslag/deel01.txt"))
     val res = <file filepath="data/reisverslag/deel01.txt">
       <dcterms:format>text/plain</dcterms:format>
     </file>


### PR DESCRIPTION
fixes EASY-1134
#### When applied it will
- Split the path to the datafile correctly, regardless of directory-names
- Add a unittest for the bug described in EASY-1134
#### Where should the reviewer @DANS-KNAW/easy start?
