### PR TITLE
Fix easy 1015 -Verify instructions.csv in the preconditions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,10 @@
             <artifactId>bagit</artifactId>
             <version>4.11.0</version>
         </dependency>
+        <dependency>
+            <groupId>nl.knaw.dans.lib</groupId>
+            <artifactId>dans-scala-lib</artifactId>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
@@ -167,7 +167,7 @@ object Main {
 
     actions
       .doOnNext(action => log.info(s"Checking preconditions of ${action.getClass.getSimpleName} ..."))
-      .foldLeft(ActionAndResult())(_ += _)
+      .foldLeft(ActionAndResult())((acc, cur) => acc += cur)
       .flatMap(_.toObservable)
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
@@ -112,7 +112,7 @@ object Main {
       CreateOutputDepositDir(row, datasetID),
       AddBagToDeposit(row, datasetID),
       AddDatasetMetadataToDeposit(row, entry),
-      AddFileMetadataToDeposit(row, datasetID),
+      AddFileMetadataToDeposit(row, entry),
       AddPropertiesToDeposit(row, entry)
     ).map(Success(_)) ++ getFileActions(dataset, extractFileParameters(dataset))
   }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
@@ -167,7 +167,7 @@ object Main {
 
     actions
       .doOnNext(action => log.info(s"Checking preconditions of ${action.getClass.getSimpleName} ..."))
-      .foldLeft(ActionAndResult())((acc, cur) => acc += cur)
+      .foldLeft(ActionAndResult())(_ += _)
       .flatMap(_.toObservable)
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -24,13 +24,11 @@ import scala.collection.mutable
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 import scala.xml.Elem
-import scala.util.matching.Regex
-import nl.knaw.dans.lib.error.{CompositeException, TraversableTryExtensions}
+import nl.knaw.dans.lib.error.TraversableTryExtensions
 
 case class AddDatasetMetadataToDeposit(row: Int, dataset: (DatasetID, Dataset))(implicit settings: Settings) extends Action {
 
   val log = LogFactory.getLog(getClass)
-
 
   def run() = {
     log.debug(s"Running $this")
@@ -47,6 +45,7 @@ case class AddDatasetMetadataToDeposit(row: Int, dataset: (DatasetID, Dataset))(
      dataset._2.toRows.flatMap( rowVals => {
       List(
         // check required fields and field dependencies, so detect any missing values
+
         // coordinates
         // point
         checkAllOrNone(row, rowVals,
@@ -70,8 +69,6 @@ case class AddDatasetMetadataToDeposit(row: Int, dataset: (DatasetID, Dataset))(
         // scheme
         checkValueIsOneOf(row, rowVals, "DCT_TEMPORAL_SCHEME", List("abr:ABRperiode")),
         checkValueIsOneOf(row, rowVals, "DC_SUBJECT_SCHEME", List("abr:ABRcomplex"))
-
-        // TODO check DEPOSITOR_ID in LDAP
       )
     }).collectResults.map(_ => ())
   }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -26,14 +26,16 @@ import scala.util.{Failure, Success, Try}
 import scala.xml.Elem
 import nl.knaw.dans.lib.error.TraversableTryExtensions
 
-case class AddDatasetMetadataToDeposit(row: Int, dataset: (DatasetID, Dataset))(implicit settings: Settings) extends Action {
+case class AddDatasetMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action {
 
   val log = LogFactory.getLog(getClass)
+
+  val (datasetID, dataset) = entry
 
   def run() = {
     log.debug(s"Running $this")
 
-    writeDatasetMetadataXml(row, dataset._1, dataset._2)
+    writeDatasetMetadataXml(row, datasetID, dataset)
   }
 
   /**
@@ -44,7 +46,7 @@ case class AddDatasetMetadataToDeposit(row: Int, dataset: (DatasetID, Dataset))(
    * @return `Success` when all preconditions are met, `Failure` otherwise
    */
   override def checkPreconditions: Try[Unit] = {
-     dataset._2.toRows.flatMap( rowVals => {
+     dataset.toRows.flatMap( rowVals => {
       List(
         // coordinates
         // point

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
@@ -45,7 +45,7 @@ case class AddFileMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(impli
   override def checkPreconditions: Try[Unit] = {
     log.debug(s"Checking preconditions for $this")
 
-    val inputDir = multiDepositDir(settings, datasetID)
+    val inputDir = settings.multidepositDir;//multiDepositDir(settings, datasetID)
     val inputDirPath = Paths.get(inputDir.getAbsolutePath)
 
     // Note that the FILE_SIP paths are not really used in this action
@@ -58,7 +58,7 @@ case class AddFileMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(impli
     if (nonExistingPaths.isEmpty)
       Success(Unit)
     else
-      Failure(ActionException(row, s"""The following SIP files are referenced in the instructions but not found in the deposit input dir for dataset "$datasetID": $nonExistingPaths""".stripMargin))
+      Failure(ActionException(row, s"""The following SIP files are referenced in the instructions but not found in the deposit input dir "$inputDirPath" for dataset "$datasetID": $nonExistingPaths""".stripMargin))
 
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
@@ -48,8 +48,7 @@ case class AddFileMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(impli
     val inputDir = multiDepositDir(settings, datasetID)
     val inputDirPath = Paths.get(inputDir.getAbsolutePath)
 
-    //println(s"inputDirPath: $inputDirPath")
-
+    // Note that the FILE_SIP paths are not really used in this action
     val nonExistingPaths = dataset.get("FILE_SIP").getOrElse(List.empty)
       .filter(fp => fp.nonEmpty)
       .filterNot(fp => {
@@ -59,7 +58,7 @@ case class AddFileMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(impli
     if (nonExistingPaths.isEmpty)
       Success(Unit)
     else
-      Failure(ActionException(row, s"""The following SIP files are referenced in the instructions but mot found in the deposit input dir for dataset "$datasetID": $nonExistingPaths""".stripMargin))
+      Failure(ActionException(row, s"""The following SIP files are referenced in the instructions but not found in the deposit input dir for dataset "$datasetID": $nonExistingPaths""".stripMargin))
 
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
@@ -24,9 +24,11 @@ import org.apache.commons.logging.LogFactory
 
 import scala.util.{Failure, Try}
 
-case class AddFileMetadataToDeposit(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action {
+case class AddFileMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action {
 
   val log = LogFactory.getLog(getClass)
+
+  val (datasetID, dataset) = entry
 
   def run() = {
     log.debug(s"Running $this")

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
@@ -20,6 +20,7 @@ import java.nio.charset.Charset
 import java.util.Properties
 import javax.naming.NamingEnumeration
 
+import nl.knaw.dans.lib.error.CompositeException
 import org.apache.commons.io.{Charsets, FileUtils}
 import org.apache.commons.lang.StringUtils
 import rx.lang.scala.{Observable, ObservableExtensions}
@@ -404,9 +405,14 @@ package object multideposit {
   def generateErrorReport[T](header: String = "", trys: Seq[Try[T]] = Nil, footer: String = ""): String = {
     header.toOption.map(s => s"$s\n").getOrElse("") +
       trys.filter(_.isFailure)
+        .flatMap {
+          case Failure(CompositeException(errors)) => errors.map(Failure(_))
+          case f@Failure(_) => List(f)
+          case _ => assert(assertion = false, "Should always get a Failure"); List.empty
+        }
         .map {
           case Failure(actionEx: ActionException) => actionEx
-          // TODO add other Failure(exceptions) cases if needed and adjust the error message below accordingly
+          // Add other Failure(exceptions) cases if needed and adjust the error message below accordingly
           case _ => throw new AssertionError("Only Failures of ActionException are expected here")
         }
         .sortBy(_.row)

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
@@ -23,7 +23,8 @@ import org.scalatest.BeforeAndAfterAll
 import rx.lang.scala.ObservableExtensions
 import rx.lang.scala.observers.TestSubscriber
 
-import scala.util.Success
+import scala.collection.mutable
+import scala.util.{Failure, Success}
 import scala.xml.{Elem, PrettyPrinter}
 
 class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
@@ -101,6 +102,111 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
   </ddm:DDM>
 
   override def afterAll = testDir.getParentFile.deleteDirectory()
+
+  "preconditions check with required person information" should "succeed" in {
+    val validDataset = mutable.HashMap(
+      "DATASET" -> List(datasetID, datasetID),
+      "DCX_CREATOR_TITLES" -> List("", ""),
+      "DCX_CREATOR_INITIALS" -> List("C.R.E.A.T.O.R.", ""),
+      "DCX_CREATOR_INSERTIONS" -> List("", ""),
+      "DCX_CREATOR_SURNAME" -> List("Creator", ""),
+      "DCX_CREATOR_DAI" -> List("", ""),
+      "DCX_CREATOR_ORGANIZATION" -> List("", "CreatorOrganisation"),
+      "DCX_CONTRIBUTOR_TITLES" -> List("", ""),
+      "DCX_CONTRIBUTOR_INITIALS" -> List("C.O.N.T.R.I.B.U.T.O.R.", ""),
+      "DCX_CONTRIBUTOR_INSERTIONS" -> List("", ""),
+      "DCX_CONTRIBUTOR_SURNAME" -> List("Contributor", ""),
+      "DCX_CONTRIBUTOR_DAI" -> List("", ""),
+      "DCX_CONTRIBUTOR_ORGANIZATION" -> List("", "ContributerOrganisation")
+    )
+    val action = new AddDatasetMetadataToDeposit(1, (datasetID, validDataset))
+
+    action.checkPreconditions shouldBe a[Success[_]]
+  }
+
+  "preconditions check with missing required person information" should "fail" in {
+    val invalidDataset = mutable.HashMap(
+      "DATASET" -> List(datasetID),
+      "DCX_CREATOR_TITLES" -> List("Prof"),
+      "DCX_CREATOR_INITIALS" -> List("F.A.I.L"),
+      "DCX_CREATOR_INSERTIONS" -> List(""),
+      "DCX_CREATOR_SURNAME" -> List(""),
+      "DCX_CREATOR_DAI" -> List("")
+    )
+    val action = new AddDatasetMetadataToDeposit(1, (datasetID, invalidDataset))
+
+    action.checkPreconditions shouldBe a[Failure[_]]
+  }
+
+  "preconditions check with missing required point coordinates" should "fail" in {
+    val invalidDataset = mutable.HashMap(
+      "DATASET" -> List(datasetID),
+      "DCX_SPATIAL_X" -> List("5"),
+      "DCX_SPATIAL_Y" -> List("")
+    )
+    val action = new AddDatasetMetadataToDeposit(1, (datasetID, invalidDataset))
+
+    action.checkPreconditions shouldBe a[Failure[_]]
+  }
+
+  "preconditions check with missing required box coordinates" should "fail" in {
+    val invalidDataset = mutable.HashMap(
+      "DATASET" -> List(datasetID),
+      "DCX_SPATIAL_NORTH" -> List("5"),
+      "DCX_SPATIAL_SOUTH" -> List(""),
+      "DCX_SPATIAL_EAST" -> List("5"),
+      "DCX_SPATIAL_WEST" -> List("5")
+    )
+    val action = new AddDatasetMetadataToDeposit(1, (datasetID, invalidDataset))
+
+    action.checkPreconditions shouldBe a[Failure[_]]
+  }
+
+  "preconditions check with required coordinates" should "succeed" in {
+    val validDataset = mutable.HashMap(
+      "DATASET" -> List(datasetID, datasetID),
+      "DCX_SPATIAL_X" -> List("5", ""),
+      "DCX_SPATIAL_Y" -> List("5", ""),
+      "DCX_SPATIAL_NORTH" -> List("5", ""),
+      "DCX_SPATIAL_SOUTH" -> List("5", ""),
+      "DCX_SPATIAL_EAST" -> List("5", ""),
+      "DCX_SPATIAL_WEST" -> List("5", "")
+    )
+    val action = new AddDatasetMetadataToDeposit(1, (datasetID, validDataset))
+
+    action.checkPreconditions shouldBe a[Success[_]]
+  }
+
+  "preconditions check with valid schemes" should "succeed" in {
+    val validDataset = mutable.HashMap(
+      "DATASET" -> List(datasetID, datasetID),
+      "DCT_TEMPORAL_SCHEME" -> List("abr:ABRperiode", ""),
+      "DC_SUBJECT_SCHEME" -> List("abr:ABRcomplex", "")
+    )
+    val action = new AddDatasetMetadataToDeposit(1, (datasetID, validDataset))
+
+    action.checkPreconditions shouldBe a[Success[_]]
+  }
+
+  "preconditions check with invalid temporal scheme" should "fail" in {
+    val invalidDataset = mutable.HashMap(
+      "DATASET" -> List(datasetID),
+      "DCT_TEMPORAL_SCHEME" -> List("invalidTemporalScheme")
+    )
+    val action = new AddDatasetMetadataToDeposit(1, (datasetID, invalidDataset))
+
+    action.checkPreconditions shouldBe a[Failure[_]]
+  }
+
+  "preconditions check with invalid subject scheme" should "fail" in {
+    val invalidDataset = mutable.HashMap(
+      "DATASET" -> List(datasetID),
+      "DC_SUBJECT_SCHEME" -> List("invalidSubjectScheme")
+    )
+    val action = new AddDatasetMetadataToDeposit(1, (datasetID, invalidDataset))
+
+    action.checkPreconditions shouldBe a[Failure[_]]
+  }
 
   "run" should "write the metadata to a file at the correct place" in {
     val file = outputDatasetMetadataFile(settings, datasetID)

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
@@ -103,6 +103,28 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
 
   override def afterAll = testDir.getParentFile.deleteDirectory()
 
+ "preconditions check with correctly corresponding access rights and audience" should "succeed" in {
+   val validDataset = mutable.HashMap(
+     "DATASET" -> List(datasetID, datasetID),
+     "DDM_ACCESSRIGHTS" -> List("GROUP_ACCESS", "OPEN_ACCESS"),
+     "DDM_AUDIENCE" -> List("D37000", "") // Archaeology
+   )
+   val action = new AddDatasetMetadataToDeposit(1, (datasetID, validDataset))
+
+   action.checkPreconditions shouldBe a[Success[_]]
+ }
+
+  "preconditions check with incorrectly corresponding access rights and audience" should "fail" in {
+    val invalidDataset = mutable.HashMap(
+      "DATASET" -> List(datasetID, datasetID),
+      "DDM_ACCESSRIGHTS" -> List("GROUP_ACCESS", ""),
+      "DDM_AUDIENCE" -> List("D30000", "") // Humanities
+    )
+    val action = new AddDatasetMetadataToDeposit(1, (datasetID, invalidDataset))
+
+    action.checkPreconditions shouldBe a[Failure[_]]
+  }
+
   "preconditions check with required person information" should "succeed" in {
     val validDataset = mutable.HashMap(
       "DATASET" -> List(datasetID, datasetID),

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
@@ -46,6 +46,13 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with Bef
 
   override def afterAll = testDir.getParentFile.deleteDirectory()
 
+  "preconditions check" should "succeed" in {
+
+    val action = new AddFileMetadataToDeposit(1, (datasetID, dataset))
+
+    action.checkPreconditions shouldBe a[Success[_]]
+  }
+
   "run" should "write the file metadata to an xml file" in {
     val action = new AddFileMetadataToDeposit(1, (datasetID, dataset))
     val metadataDir = outputDepositBagMetadataDir(settings, datasetID)

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
@@ -21,7 +21,7 @@ import nl.knaw.dans.easy.multideposit.{Settings, UnitSpec, _}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import scala.collection.mutable
-import scala.util.Success
+import scala.util.{Failure, Success}
 import scala.xml.PrettyPrinter
 
 class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with BeforeAndAfterAll {
@@ -46,11 +46,21 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with Bef
 
   override def afterAll = testDir.getParentFile.deleteDirectory()
 
-  "preconditions check" should "succeed" in {
+  "preconditions check with existing SIP files" should "succeed" in {
 
     val action = new AddFileMetadataToDeposit(1, (datasetID, dataset))
 
     action.checkPreconditions shouldBe a[Success[_]]
+  }
+
+  "preconditions check with non-existing SIP files" should "fail" in {
+    val invalidDataset = mutable.HashMap(
+      "DATASET" -> List(datasetID, datasetID, datasetID),
+      "FILE_SIP" -> List("reisverslag/deel01.txt", "", "non-existing-file-path")
+    )
+    val action = new AddFileMetadataToDeposit(1, (datasetID, invalidDataset))
+
+    action.checkPreconditions shouldBe a[Failure[_]]
   }
 
   "run" should "write the file metadata to an xml file" in {

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
@@ -20,6 +20,7 @@ import java.io.File
 import nl.knaw.dans.easy.multideposit.{Settings, UnitSpec, _}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
+import scala.collection.mutable
 import scala.util.Success
 import scala.xml.PrettyPrinter
 
@@ -30,7 +31,10 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with Bef
     outputDepositDir = new File(testDir, "dd")
   )
   val datasetID = "ruimtereis01"
-
+  val dataset = mutable.HashMap(
+    "DATASET" -> List(datasetID, datasetID),
+    "FILE_SIP" -> List("reisverslag/deel01.txt", "")
+  )
   before {
     new File(getClass.getResource("/spacetravel").toURI)
       .copyDir(settings.outputDepositDir)
@@ -43,7 +47,7 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with Bef
   override def afterAll = testDir.getParentFile.deleteDirectory()
 
   "run" should "write the file metadata to an xml file" in {
-    val action = new AddFileMetadataToDeposit(1, datasetID)
+    val action = new AddFileMetadataToDeposit(1, (datasetID, dataset))
     val metadataDir = outputDepositBagMetadataDir(settings, datasetID)
 
     action.run() shouldBe a[Success[_]]

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
@@ -33,7 +33,7 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with Bef
   val datasetID = "ruimtereis01"
   val dataset = mutable.HashMap(
     "DATASET" -> List(datasetID, datasetID),
-    "FILE_SIP" -> List("reisverslag/deel01.txt", "")
+    "FILE_SIP" -> List("ruimtereis01/reisverslag/deel01.txt", "")
   )
   before {
     new File(getClass.getResource("/spacetravel").toURI)
@@ -56,7 +56,7 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with Bef
   "preconditions check with non-existing SIP files" should "fail" in {
     val invalidDataset = mutable.HashMap(
       "DATASET" -> List(datasetID, datasetID, datasetID),
-      "FILE_SIP" -> List("reisverslag/deel01.txt", "", "non-existing-file-path")
+      "FILE_SIP" -> List("ruimtereis01/reisverslag/deel01.txt", "", "non-existing-file-path")
     )
     val action = new AddFileMetadataToDeposit(1, (datasetID, invalidDataset))
 


### PR DESCRIPTION
fixes EASY-1015
Verify instructions.csv in the preconditions

#### When applied it will
* check that files that are mentioned in the instructions.csv file should exist in the multi-deposit-directory
* check some dataset metadata fields from the instructions.csv file


#### Where should the reviewer @DANS-KNAW/easy start?
AddFileMetadataToDeposit.checkPreconditions
AddDatasetMetadataToDeposit.checkPreconditions

#### How should this be manually tested?
Use the 'spacetravel' test resources to run the easy_split_multi_deposit on a test server, could be deasy. After building, but before testing,  make sure you run ./deploy-role easy_split_multi_deposit!

Introduce potential problems by renaming a file or changing/removing some of the files mentioned in the instructions.csv. This should result in an error message pointing to the missing file. Also remove some required field for the creator or contributor, for instance the initials. After running also this should result in error messages pointing to the missing required values.  
