### PR TITLE
Fix easy 1166

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ARGUMENTS
                                  RFC4180 format.
     deposit-dir (required)         A directory in which the deposit directories must be created. The deposit
                                  directory layout is described in the easy-sword2 documentation
-    datamanager (required)         The user id of the datamanger (archivist) performing this deposit
+    datamanager (required)         The username (id) of the datamanger (archivist) performing this deposit
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -47,19 +47,18 @@ ARGUMENTS
 
   Options:
 
+    -s, --springfield-inbox  <arg>   The inbox directory of a Springfield Streaming Media Platform installation.
+                                     If not specified the value of springfield-inbox in application.properties
+                                     is used. (default = data/springfield-inbox)
+        --help                       Show help message
+        --version                    Show version of this program
 
-  -s, --springfield-inbox  <arg>   The inbox directory of a Springfield Streaming Media Platform installation.
-                                   If not specified the value of springfield-inbox in application.properties
-                                   is used. 
-      --help                       Show help message
-      --version                    Show version of this program
-
- trailing arguments:
+   trailing arguments:
     multi-deposit-dir (required)   Directory containing the Submission Information Package to process. This must
-                                 be a valid path to a directory containing a file named 'instructions.csv' in
-                                 RFC4180 format.
+                                   be a valid path to a directory containing a file named 'instructions.csv' in
+                                   RFC4180 format.
     deposit-dir (required)         A directory in which the deposit directories must be created. The deposit
-                                 directory layout is described in the easy-sword2 documentation
+                                   directory layout is described in the easy-sword2 documentation
     datamanager (required)         The username (id) of the datamanger (archivist) performing this deposit
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ easy-split-multi-deposit
 ========================
 [![Build Status](https://travis-ci.org/DANS-KNAW/easy-split-multi-deposit.png?branch=master)](https://travis-ci.org/DANS-KNAW/easy-split-multi-deposit)
 
-Convert a Multi-Deposit splitting it into several Dataset Deposits.
+Splits a Multi-Deposit into several deposit directories for subsequent ingest into the archive
+Utility to process a Multi-Deposit prior to ingestion into the DANS EASY Archive
 
 SYNOPSIS
 --------
@@ -12,7 +13,6 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-
 A command line tool to process a Multi-Deposit into several Dataset Deposit. A Multi-Deposit
 is a deposit containing data files and metadata for several datasets. The tool splits the
 Multi-Deposit into separate Dataset Deposit directories that can be ingested into the archive by 
@@ -41,25 +41,26 @@ If the MDI file is found and is correct the following actions are taken:
 ARGUMENTS
 ---------
 ```
-Usage: easy-split-multi-deposit.sh [{--springfield-inbox|-s} <dir>] <multi-deposit-dir> <output-deposits-dir>
-Options:
+  Usage: 
 
-  -s, --springfield-inbox  <arg>   The inbox directory of a Springfield Streaming
-                                   Media Platform installation. If not specified
-                                   the value of springfield-inbox in
-                                   application.properties is used.
-                                   (default = /vagrant/shared/springfield-inbox)
+      easy-split-multi-deposit.sh [{--springfield-inbox|-s} <dir>] <multi-deposit-dir> <output-deposits-dir> <datamanager>
+
+  Options:
+
+
+  -s, --springfield-inbox  <arg>   The inbox directory of a Springfield Streaming Media Platform installation.
+                                   If not specified the value of springfield-inbox in application.properties
+                                   is used. 
       --help                       Show help message
       --version                    Show version of this program
 
  trailing arguments:
-  multi-deposit-dir (required)   Directory containing the Submission Information
-                                 Package to process. This must be a valid path to
-                                 a directory containing a file named
-                                 'instructions.csv' in RFC4180 format.
-  deposit-dir (required)         A directory in which the deposit directories must
-                                 be created. The deposit directory layout is
-                                 described in the easy-sword2 documentation
+    multi-deposit-dir (required)   Directory containing the Submission Information Package to process. This must
+                                 be a valid path to a directory containing a file named 'instructions.csv' in
+                                 RFC4180 format.
+    deposit-dir (required)         A directory in which the deposit directories must be created. The deposit
+                                 directory layout is described in the easy-sword2 documentation
+    datamanager (required)         The user id of the datamanger (archivist) performing this deposit
 ```
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,11 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
+                <configuration combine.self="override">
+                    <excludes>
+                        <exclude>data/</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
@@ -21,7 +21,9 @@ import javax.naming.ldap.InitialLdapContext
 
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
-import org.rogach.scallop.{ ScallopConf, ScallopOption }
+import org.rogach.scallop.{ScallopConf, ScallopOption}
+
+import scala.util.{Failure, Success, Try}
 
 object CommandLineOptions extends DebugEnhancedLogging {
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
@@ -68,12 +68,15 @@ class ScallopCommandLine(props: PropertiesConfiguration, args: Array[String]) ex
 
   printedName = "easy-split-multi-deposit"
   version(s"$printedName ${Version()}")
+  val description = "Splits a Multi-Deposit into several deposit directories for subsequent ingest into the archive"
+  val synopsis = s"""$printedName.sh [{--springfield-inbox|-s} <dir>] <multi-deposit-dir> <output-deposits-dir> <datamanager>"""
   banner(s"""
-           |Splits a Multi-Deposit into several deposit directories for subsequent ingest into the archive
-           |Utility to process a Multi-Deposit prior to ingestion into the DANS EASY Archive
+           |  $description
+           |  Utility to process a Multi-Deposit prior to ingestion into the DANS EASY Archive
            |
            |Usage:
-           |  $printedName.sh [{--springfield-inbox|-s} <dir>] <multi-deposit-dir> <output-deposits-dir> <datamanager>
+           |
+           |  $synopsis
            |
            |Options:
            |""".stripMargin)

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
@@ -41,6 +41,7 @@ object CommandLineOptions extends DebugEnhancedLogging {
       multidepositDir = opts.multiDepositDir(),
       springfieldInbox = opts.springfieldInbox(),
       outputDepositDir = opts.outputDepositDir(),
+      datamanager = opts.datamanager(),
       ldap = {
         val env = new java.util.Hashtable[String, String]
         env.put(Context.PROVIDER_URL, props.getString("auth.ldap.url"))
@@ -69,7 +70,7 @@ class ScallopCommandLine(props: PropertiesConfiguration, args: Array[String]) ex
            |Utility to process a Multi-Deposit prior to ingestion into the DANS EASY Archive
            |
            |Usage:
-           |  $printedName.sh [{--springfield-inbox|-s} <dir>] <multi-deposit-dir> <output-deposits-dir>
+           |  $printedName.sh [{--springfield-inbox|-s} <dir>] <multi-deposit-dir> <output-deposits-dir> <datamanager>
            |
            |Options:
            |""".stripMargin)
@@ -92,6 +93,11 @@ class ScallopCommandLine(props: PropertiesConfiguration, args: Array[String]) ex
     required = true,
     descr = "A directory in which the deposit directories must be created. "
       + "The deposit directory layout is described in the easy-sword2 documentation")
+
+  val datamanager: ScallopOption[String] = trailArg[String](
+    name = "datamanager",
+    required = true,
+    descr = "The user id of the datamanger (archivist) performing this deposit")
 
   validateFileExists(multiDepositDir)
   validateFileIsDirectory(multiDepositDir)

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
@@ -69,6 +69,7 @@ class ScallopCommandLine(props: PropertiesConfiguration, args: Array[String]) ex
   printedName = "easy-split-multi-deposit"
   version(s"$printedName ${Version()}")
   banner(s"""
+           |Splits a Multi-Deposit into several deposit directories for subsequent ingest into the archive
            |Utility to process a Multi-Deposit prior to ingestion into the DANS EASY Archive
            |
            |Usage:

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
@@ -100,7 +100,7 @@ class ScallopCommandLine(props: PropertiesConfiguration, args: Array[String]) ex
   val datamanager: ScallopOption[String] = trailArg[String](
     name = "datamanager",
     required = true,
-    descr = "The user id of the datamanger (archivist) performing this deposit")
+    descr = "The username (id) of the datamanger (archivist) performing this deposit")
 
   validateFileExists(multiDepositDir)
   validateFileIsDirectory(multiDepositDir)

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
@@ -44,6 +44,7 @@ package object multideposit {
   case class Settings(multidepositDir: File = null,
                       springfieldInbox: File = null,
                       outputDepositDir: File = null,
+                      datamanager: String = null,
                       ldap: Ldap = null) {
     override def toString: String =
       s"Settings(multideposit-dir=$multidepositDir, " +

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
@@ -49,7 +49,8 @@ package object multideposit {
     override def toString: String =
       s"Settings(multideposit-dir=$multidepositDir, " +
         s"springfield-inbox=$springfieldInbox, " +
-        s"deposit-dir=$outputDepositDir)"
+        s"deposit-dir=$outputDepositDir, " +
+        s"datamanager=$datamanager)"
   }
 
   case class EmptyInstructionsFileException(file: File) extends Exception(s"The given instructions file in '$file' is empty")

--- a/src/test/resources/allfields/output/input-ruimtereis01/deposit.properties
+++ b/src/test/resources/allfields/output/input-ruimtereis01/deposit.properties
@@ -1,5 +1,7 @@
 #
-#Thu Dec 01 12:41:08 CET 2016
-state.description=Deposit is valid and ready for post-submission processing
+#Mon Feb 06 15:42:15 CET 2017
+datamanager.email=FILL.IN.YOUR@VALID-EMAIL.NL
+datamanager.userId=easyadmin
 depositor.userId=user001
+state.description=Deposit is valid and ready for post-submission processing
 state.label=SUBMITTED

--- a/src/test/resources/allfields/output/input-ruimtereis02/deposit.properties
+++ b/src/test/resources/allfields/output/input-ruimtereis02/deposit.properties
@@ -1,5 +1,7 @@
 #
-#Thu Dec 01 12:41:08 CET 2016
-state.description=Deposit is valid and ready for post-submission processing
+#Mon Feb 06 15:42:14 CET 2017
+datamanager.email=FILL.IN.YOUR@VALID-EMAIL.NL
+datamanager.userId=easyadmin
 depositor.userId=user001
+state.description=Deposit is valid and ready for post-submission processing
 state.label=SUBMITTED

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/CustomMatchers.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/CustomMatchers.scala
@@ -37,5 +37,3 @@ trait CustomMatchers {
   }
   def containTrimmed(content: String) = new ContentMatcher(content)
 }
-
-object CustomMatchers extends CustomMatchers

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/CustomMatchers.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/CustomMatchers.scala
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.multideposit
+
+import java.io.File
+
+import scala.io.Source
+
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+/** Does not dump the full file but just the searched content if it is not found.
+  *
+  * See also <a href="http://www.scalatest.org/user_guide/using_matchers#usingCustomMatchers">CustomMatchers</a> */
+trait CustomMatchers {
+  class ContentMatcher(content: String) extends Matcher[File] {
+    def apply(left: File): MatchResult = {
+      def trimLines(s: String): String = s.split("\n").map(_.trim).mkString("\n")
+      MatchResult(
+        trimLines(Source.fromFile(left).mkString).contains(trimLines(content)),
+        s"$left did not contain: $content" ,
+        s"$left contains $content"
+      )
+    }
+  }
+  def containTrimmed(content: String) = new ContentMatcher(content)
+}
+
+object CustomMatchers extends CustomMatchers

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -21,19 +21,23 @@ import org.apache.commons.configuration.PropertiesConfiguration
 import org.scalatest._
 
 class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
+  val RES_DIR_STR = "src/test/resources/"//new File(getClass.getResource("/").toURI).getAbsolutePath
+  println(s"Resource dir: ${new File(RES_DIR_STR).getAbsolutePath}")
+  println(s"Resource dir esits: ${new File(RES_DIR_STR).getAbsoluteFile.exists()}")
+  new File(RES_DIR_STR).listFiles().map(println(_))
+
+  val mockedProps = {
+    val ps = new PropertiesConfiguration()
+    ps.setDelimiterParsingDisabled(true)
+    ps.load(new File(RES_DIR_STR + "/debug-config", "application.properties"))
+    ps
+  }
+  val mockedArgs = Array(RES_DIR_STR + "/allfields/input", RES_DIR_STR + "/allfields/output", "datamanager")
+  val clo = new ScallopCommandLine(mockedProps, mockedArgs)
   private val helpInfo = {
-    val RES_DIR_STR = "src/test/resources/"//new File(getClass.getResource("/").toURI).getAbsolutePath
-    println(s"Resource dir: ${new File(RES_DIR_STR).getAbsolutePath}")
-    val mockedProps = {
-      val ps = new PropertiesConfiguration()
-      ps.setDelimiterParsingDisabled(true)
-      ps.load(new File(RES_DIR_STR + "/debug-config", "application.properties"))
-      ps
-    }
-    val mockedArgs = Array(RES_DIR_STR + "/allfields/input", RES_DIR_STR + "/allfields/output", "datamanager")
     val mockedStdOut = new ByteArrayOutputStream()
     Console.withOut(mockedStdOut) {
-      new ScallopCommandLine(mockedProps, mockedArgs).printHelp()
+      clo.printHelp()
     }
     mockedStdOut.toString
   }
@@ -44,13 +48,11 @@ class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
   }
 
   "synopsis in help info" should "be part of README.md" in {
-    val synopsis = helpInfo.split("Options:")(0).split("Usage:")(1)
-    new File("README.md") should containTrimmed(synopsis)
+    new File("README.md") should containTrimmed(clo.synopsis)
   }
 
-  "first banner line" should "be part of README.md and pom.xml" in {
-    val description = helpInfo.split("\n")(2)
-    new File("README.md") should containTrimmed(description)
-    new File("pom.xml") should containTrimmed(s"<description>$description</description>")
+  "description line(s) in help info" should "be part of README.md and pom.xml" in {
+    new File("README.md") should containTrimmed(clo.description)
+    new File("pom.xml") should containTrimmed(clo.description)
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -22,7 +22,8 @@ import org.scalatest._
 
 class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
   private val helpInfo = {
-    val RES_DIR_STR = new File(getClass.getResource("/").toURI).toString
+    val RES_DIR_STR = new File(getClass.getResource("/").toURI).getAbsolutePath
+    println(s"Resource dir: $RES_DIR_STR")
     val mockedProps = {
       val ps = new PropertiesConfiguration()
       ps.setDelimiterParsingDisabled(true)

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -22,14 +22,14 @@ import org.scalatest._
 
 class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
   private val helpInfo = {
-    val RES_DIR_STR = "src/test/resources/"
+    val RES_DIR_STR = new File(getClass.getResource("/").toURI).toString
     val mockedProps = {
       val ps = new PropertiesConfiguration()
       ps.setDelimiterParsingDisabled(true)
-      ps.load(new File(RES_DIR_STR + "debug-config", "application.properties"))
+      ps.load(new File(RES_DIR_STR + "/debug-config", "application.properties"))
       ps
     }
-    val mockedArgs = Array(RES_DIR_STR + "allfields/input", RES_DIR_STR + "allfields/output", "datamanager")
+    val mockedArgs = Array(RES_DIR_STR + "/allfields/input", RES_DIR_STR + "/allfields/output", "datamanager")
     val mockedStdOut = new ByteArrayOutputStream()
     Console.withOut(mockedStdOut) {
       new ScallopCommandLine(mockedProps, mockedArgs).printHelp()

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -32,7 +32,7 @@ class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
     ps.load(new File(RES_DIR_STR + "/debug-config", "application.properties"))
     ps
   }
-  val mockedArgs = Array(RES_DIR_STR + "/allfields/input", RES_DIR_STR + "/allfields/output", "datamanager")
+  val mockedArgs = Array("-s", RES_DIR_STR, RES_DIR_STR + "/allfields/input", RES_DIR_STR + "/allfields/output", "datamanager")
   val clo = new ScallopCommandLine(mockedProps, mockedArgs)
   private val helpInfo = {
     val mockedStdOut = new ByteArrayOutputStream()

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -22,8 +22,8 @@ import org.scalatest._
 
 class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
   private val helpInfo = {
-    val RES_DIR_STR = new File(getClass.getResource("/").toURI).getAbsolutePath
-    println(s"Resource dir: $RES_DIR_STR")
+    val RES_DIR_STR = "src/test/resources/"//new File(getClass.getResource("/").toURI).getAbsolutePath
+    println(s"Resource dir: ${new File(RES_DIR_STR).getAbsolutePath}")
     val mockedProps = {
       val ps = new PropertiesConfiguration()
       ps.setDelimiterParsingDisabled(true)

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -17,11 +17,10 @@ package nl.knaw.dans.easy.multideposit
 
 import java.io.{ByteArrayOutputStream, File}
 
-import nl.knaw.dans.easy.multideposit.CustomMatchers._
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.scalatest._
 
-class ReadmeSpec extends FlatSpec with Matchers {
+class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
   private val helpInfo = {
     val RES_DIR_STR = "src/test/resources/"
     val mockedProps = {

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -21,7 +21,7 @@ import org.apache.commons.configuration.PropertiesConfiguration
 import org.scalatest._
 
 class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
-  val RES_DIR_STR = new File(getClass.getResource("/").toURI).getAbsolutePath//"src/test/resources/"//new File(getClass.getResource("/").toURI).getAbsolutePath
+  val RES_DIR_STR = new File(getClass.getResource("/").toURI).getAbsolutePath
 
   val mockedProps = {
     val ps = new PropertiesConfiguration()

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.multideposit
+
+import java.io.{ByteArrayOutputStream, File}
+
+import nl.knaw.dans.easy.multideposit.CustomMatchers._
+import org.apache.commons.configuration.PropertiesConfiguration
+import org.scalatest._
+
+class ReadmeSpec extends FlatSpec with Matchers {
+  private val helpInfo = {
+    val RES_DIR_STR = "src/test/resources/"
+    val mockedProps = {
+      val ps = new PropertiesConfiguration()
+      ps.setDelimiterParsingDisabled(true)
+      ps.load(new File(RES_DIR_STR + "debug-config", "application.properties"))
+      ps
+    }
+    val mockedArgs = Array(RES_DIR_STR + "allfields/input", RES_DIR_STR + "allfields/output", "datamanager")
+    val mockedStdOut = new ByteArrayOutputStream()
+    Console.withOut(mockedStdOut) {
+      new ScallopCommandLine(mockedProps, mockedArgs).printHelp()
+    }
+    mockedStdOut.toString
+  }
+
+  "arguments" should "be part of README.md" in {
+    val options = helpInfo.replaceAll("\\(default[^)]+\\)","").split("Options:")(1)
+    new File("README.md") should containTrimmed(options)
+  }
+
+  "synopsis in help info" should "be part of README.md" in {
+    val synopsis = helpInfo.split("Options:")(0).split("Usage:")(1)
+    new File("README.md") should containTrimmed(synopsis)
+  }
+
+  "first banner line" should "be part of README.md and pom.xml" in {
+    val description = helpInfo.split("\n")(2)
+    new File("README.md") should containTrimmed(description)
+    new File("pom.xml") should containTrimmed(s"<description>$description</description>")
+  }
+}

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -21,10 +21,7 @@ import org.apache.commons.configuration.PropertiesConfiguration
 import org.scalatest._
 
 class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
-  val RES_DIR_STR = "src/test/resources/"//new File(getClass.getResource("/").toURI).getAbsolutePath
-  println(s"Resource dir: ${new File(RES_DIR_STR).getAbsolutePath}")
-  println(s"Resource dir esits: ${new File(RES_DIR_STR).getAbsoluteFile.exists()}")
-  new File(RES_DIR_STR).listFiles().map(println(_))
+  val RES_DIR_STR = new File(getClass.getResource("/").toURI).getAbsolutePath//"src/test/resources/"//new File(getClass.getResource("/").toURI).getAbsolutePath
 
   val mockedProps = {
     val ps = new PropertiesConfiguration()

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -29,8 +29,11 @@ class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
     ps.load(new File(RES_DIR_STR + "/debug-config", "application.properties"))
     ps
   }
+
   val mockedArgs = Array("-s", RES_DIR_STR, RES_DIR_STR + "/allfields/input", RES_DIR_STR + "/allfields/output", "datamanager")
+
   val clo = new ScallopCommandLine(mockedProps, mockedArgs)
+
   private val helpInfo = {
     val mockedStdOut = new ByteArrayOutputStream()
     Console.withOut(mockedStdOut) {
@@ -39,8 +42,10 @@ class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
     mockedStdOut.toString
   }
 
-  "arguments" should "be part of README.md" in {
-    val options = helpInfo.replaceAll("\\(default[^)]+\\)","").split("Options:")(1)
+  "options in help info" should "be part of README.md" in {
+    val lineSeparators = s"(${System.lineSeparator()})+"
+    val options = helpInfo.split(s"${lineSeparators}Options:$lineSeparators")(1)
+    options.trim.length shouldNot be (0)
     new File("README.md") should containTrimmed(options)
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -48,11 +48,14 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with Befor
   def createDatamanagerAttributes(state: String = "ACTIVE",
                                   roles: Seq[String] = Seq("USER","ARCHIVIST"),
                                   mail: String = "dm@test.org"): BasicAttributes = {
-    val r = new BasicAttribute("easyRoles")
-    roles.foreach(r.add)
+
     val a = new BasicAttributes()
     a.put("dansState", state)
-    a.put(r)
+    a.put({
+      val r = new BasicAttribute("easyRoles")
+      roles.foreach(r.add)
+      r
+    })
     a.put("mail", mail)
     a
   }


### PR DESCRIPTION
fixes EASY-1166

#### When applied it will
* using an extra trailing argument for the datamanager username, it will retrieve the email address 


#### Where should the reviewer @DANS-KNAW/easy start?
AddPropertiesToDeposit

#### How should this be manually tested?
run the command with a datamanager that is an active user and an activist and then look into the property files in the bags
