### PR TITLE
EASY-1166 update

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -339,7 +339,7 @@ object validators {
       .map(illegalCharacters => if (illegalCharacters.isEmpty)
                                   Success(())
                                 else
-                                  Failure(ActionException(row, s"The column '$key' contains the following invalid characters: ${ illegalCharacters.mkString("{ ", ", ", " }") }"))
+                                  Failure(ActionException(row, s"The column '$key' contains the following invalid characters: ${ illegalCharacters.map(s => s"'$s'").mkString("{ ", ", ", " }") }"))
       ).getOrElse(Success(()))
   }
   /**

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -62,6 +62,12 @@ object AddDatasetMetadataToDeposit {
         // date created format
         checkDateFormatting(row, rowVals, "DDM_CREATED"),
 
+        // only valid chars allowed
+        checkValidChars(row, rowVals, "SF_COLLECTION"),
+        checkValidChars(row, rowVals, "SF_DOMAIN"),
+        checkValidChars(row, rowVals, "SF_USER"),
+        checkValidChars(row, rowVals, "DATASET"),
+
         // coordinates
         // point
         checkAllOrNone(row, rowVals, "DCX_SPATIAL_X", "DCX_SPATIAL_Y"),
@@ -326,6 +332,16 @@ object AddDatasetMetadataToDeposit {
 }
 
 object validators {
+
+  def checkValidChars(row: Int, datasetRow: DatasetRow, key: String): Try[Unit] = {
+    datasetRow.get(key)
+      .map(value => "[^a-zA-Z0-9_-]".r.findAllIn(value).toSet)
+      .map(illegalCharacters => if (illegalCharacters.isEmpty)
+                                  Success(())
+                                else
+                                  Failure(ActionException(row, s"The column '$key' contains the following invalid characters: ${ illegalCharacters.mkString("{ ", ", ", " }") }"))
+      ).getOrElse(Success(()))
+  }
   /**
    * Check if either non of the keys have values or all of them have values
    * If some are missing, mention them in the exception message

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -61,6 +61,7 @@ object AddDatasetMetadataToDeposit {
       List(
         // date created format
         checkDateFormatting(row, rowVals, "DDM_CREATED"),
+        checkDateFormatting(row, rowVals, "DDM_AVAILABLE"),
 
         // only valid chars allowed
         checkValidChars(row, rowVals, "SF_COLLECTION"),
@@ -436,7 +437,7 @@ object validators {
   def checkDateFormatting(row: Int, datasetRow: DatasetRow, key: String): Try[Unit] = {
     datasetRow.get(key)
       .map(date => Try { DateTime.parse(date) }.map(_ => ()).recoverWith {
-        case _: IllegalArgumentException => Failure(ActionException(row, s"'$date' does not represent a date"))
+        case _: IllegalArgumentException => Failure(ActionException(row, s"$key '$date' does not represent a date"))
       })
       .getOrElse(Success(()))
   }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateOutputDepositDir.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateOutputDepositDir.scala
@@ -27,25 +27,12 @@ case class CreateOutputDepositDir(row: Int, datasetID: DatasetID)(implicit setti
   private val metadataDir = outputDepositBagMetadataDir(datasetID)
   private val dirs = depositDir :: bagDir :: metadataDir :: Nil
 
-  override def checkPreconditions: Try[Unit] = {
-    for {
-      _ <- checkDatasetIdIsValid
-      _ <- checkDirectoriesDoNotExist
-    } yield ()
-  }
+  override def checkPreconditions: Try[Unit] = checkDirectoriesDoNotExist
 
   private def checkDirectoriesDoNotExist: Try[Unit] = {
     dirs.find(_.exists)
       .map(file => Failure(ActionException(row, s"The deposit for dataset $datasetID already exists in $file.")))
       .getOrElse(Success(()))
-  }
-
-  private def checkDatasetIdIsValid: Try[Unit] = {
-    val illegalCharacters = "[^a-zA-Z0-9_-]".r.findAllIn(datasetID).toSet
-    if (illegalCharacters.isEmpty)
-      Success(())
-    else
-      Failure(ActionException(row, s"The datasetId '$datasetID' contains the following invalid characters: ${ illegalCharacters.mkString("{ ", ", ", " }") }"))
   }
 
   override def execute(): Try[Unit] = {

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -32,7 +32,10 @@ class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
 
   val mockedArgs = Array("-s", RES_DIR_STR, RES_DIR_STR + "/allfields/input", RES_DIR_STR + "/allfields/output", "datamanager")
 
-  val clo = new ScallopCommandLine(mockedProps, mockedArgs)
+  private val clo = new ScallopCommandLine(mockedProps, mockedArgs) {
+    // avoids System.exit() in case of invalid arguments or "--help"
+    override def verify(): Unit = {}
+  }
 
   private val helpInfo = {
     val mockedStdOut = new ByteArrayOutputStream()

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
@@ -481,6 +481,32 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
     }
   }
 
+  it should "fail if the SF_COLLECTION contains forbidden characters" in {
+    val dataset = mutable.HashMap(
+      "DATASET" -> List("no_weird_char"),
+      "DDM_CREATED" -> List("2017-07-30"),
+      "SF_COLLECTION" -> List("do main")
+    )
+    inside(new AddDatasetMetadataToDeposit(1, ("no_weird_char", dataset)).checkPreconditions) {
+      case Failure(CompositeException(es)) =>
+        val ActionException(_, message, _) :: Nil = es.toList
+        message shouldBe "The column 'SF_COLLECTION' contains the following invalid characters: { ' ' }"
+    }
+  }
+
+  it should "fail if the SF_USER contains forbidden characters" in {
+    val dataset = mutable.HashMap(
+      "DATASET" -> List("no_weird_char"),
+      "DDM_CREATED" -> List("2017-07-30"),
+      "SF_USER" -> List("do%main")
+    )
+    inside(new AddDatasetMetadataToDeposit(1, ("no_weird_char", dataset)).checkPreconditions) {
+      case Failure(CompositeException(es)) =>
+        val ActionException(_, message, _) :: Nil = es.toList
+        message shouldBe "The column 'SF_USER' contains the following invalid characters: { '%' }"
+    }
+  }
+
   it should "fail if the SF_DOMAIN contains forbidden characters" in {
     val dataset = mutable.HashMap(
       "DATASET" -> List("no_weird_char"),
@@ -490,7 +516,7 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
     inside(new AddDatasetMetadataToDeposit(1, ("no_weird_char", dataset)).checkPreconditions) {
       case Failure(CompositeException(es)) =>
         val ActionException(_, message, _) :: Nil = es.toList
-        message shouldBe "The column 'SF_DOMAIN' contains the following invalid characters: { / }"
+        message shouldBe "The column 'SF_DOMAIN' contains the following invalid characters: { '/' }"
     }
   }
 
@@ -502,7 +528,7 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
     inside(new AddDatasetMetadataToDeposit(1, ("weird#char", dataset)).checkPreconditions) {
       case Failure(CompositeException(es)) =>
         val ActionException(_, message, _) :: Nil = es.toList
-        message shouldBe "The column 'DATASET' contains the following invalid characters: { # }"
+        message shouldBe "The column 'DATASET' contains the following invalid characters: { '#' }"
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
@@ -481,6 +481,32 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
     }
   }
 
+  it should "fail if the SF_DOMAIN contains forbidden characters" in {
+    val dataset = mutable.HashMap(
+      "DATASET" -> List("no_weird_char"),
+      "DDM_CREATED" -> List("2017-07-30"),
+      "SF_DOMAIN" -> List("do/main")
+    )
+    inside(new AddDatasetMetadataToDeposit(1, ("no_weird_char", dataset)).checkPreconditions) {
+      case Failure(CompositeException(es)) =>
+        val ActionException(_, message, _) :: Nil = es.toList
+        message shouldBe "The column 'SF_DOMAIN' contains the following invalid characters: { / }"
+    }
+  }
+
+  it should "fail if the DATASET contains forbidden characters" in {
+    val dataset = mutable.HashMap(
+      "DATASET" -> List("weird#char"),
+      "DDM_CREATED" -> List("2017-07-30")
+    )
+    inside(new AddDatasetMetadataToDeposit(1, ("weird#char", dataset)).checkPreconditions) {
+      case Failure(CompositeException(es)) =>
+        val ActionException(_, message, _) :: Nil = es.toList
+        message shouldBe "The column 'DATASET' contains the following invalid characters: { # }"
+    }
+  }
+
+
   "execute" should "write the metadata to a file at the correct place" in {
     val file = outputDatasetMetadataFile(datasetID)
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
@@ -428,7 +428,7 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
     inside(new AddDatasetMetadataToDeposit(1, (datasetID, dataset)).checkPreconditions) {
       case Failure(CompositeException(es)) =>
         val ActionException(_, message, _) :: Nil = es.toList
-        message shouldBe "'foobar' does not represent a date"
+        message shouldBe "DDM_CREATED 'foobar' does not represent a date"
     }
   }
 
@@ -438,6 +438,19 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
       "DDM_CREATED" -> List("2017-07-30T09:00:34.921+02:00")
     )
     new AddDatasetMetadataToDeposit(1, (datasetID, dataset)).checkPreconditions shouldBe a[Success[_]]
+  }
+
+  it should "fail when the DDM_AVAILABLE column contains a wrong format" in {
+    val dataset = mutable.HashMap(
+      "DATASET" -> List(datasetID),
+      "DDM_CREATED" -> List("2017-07-30"),
+      "DDM_AVAILABLE" -> List("01-01-2017")
+    )
+    inside(new AddDatasetMetadataToDeposit(1, (datasetID, dataset)).checkPreconditions) {
+        case Failure(CompositeException(es)) =>
+          val ActionException(_, message, _) :: Nil = es.toList
+          message shouldBe "DDM_AVAILABLE '01-01-2017' does not represent a date"
+      }
   }
 
   it should "succeed when the SF columns only contain one row with values" in {

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -101,7 +101,7 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with Befor
       case Failure(CompositeException(es)) =>
         es should have size 1
         val ActionException(_, message, _) :: Nil = es
-        message should include ("""DatamanagerID "dm" is unknown""")
+        message should include ("""The datamanager "dm" is unknown""")
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/CreateOutputDepositDirSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/CreateOutputDepositDirSpec.scala
@@ -72,12 +72,6 @@ class CreateOutputDepositDirSpec extends UnitSpec with BeforeAndAfter with Befor
     }
   }
 
-  it should "fail if the datasetId contains forbidden characters" in {
-    inside(CreateOutputDepositDir(1, datasetID + "#" + datasetID).checkPreconditions) {
-      case Failure(ActionException(_, message, _)) => message shouldBe s"The datasetId '$datasetID#$datasetID' contains the following invalid characters: { # }"
-    }
-  }
-
   "execute" should "create the directories" in {
     // test is in seperate function,
     // since we want to reuse the code


### PR DESCRIPTION
update on EASY-1166

#### When applied it will
* Override ScallopConf.verify, as suggested by @jo-pol in #45 
* Check whether DATASET, SF_DOMAIN, SF_COLLECTION and SF_USER only contain valid chars
* Log row-number '-1' for preconditions that pertain to the cmdline parameter DATAMANAGER

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

