### PR TITLE
EASY-1225 set deposit permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.35</version>
+        <version>1.42</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-split-multi-deposit</artifactId>
@@ -152,11 +152,11 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <configuration combine.self="override">
-                    <excludes>
-                        <exclude>data/</exclude>
-                    </excludes>
-                </configuration>
+                <!--<configuration combine.self="override">-->
+                    <!--<excludes>-->
+                        <!--<exclude>data/</exclude>-->
+                    <!--</excludes>-->
+                <!--</configuration>-->
             </plugin>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -152,11 +152,6 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <!--<configuration combine.self="override">-->
-                    <!--<excludes>-->
-                        <!--<exclude>data/</exclude>-->
-                    <!--</excludes>-->
-                <!--</configuration>-->
             </plugin>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -28,7 +28,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.build.directory}</directory>
-            <outputDirectory>/bin</outputDirectory>
+            <outputDirectory>bin</outputDirectory>
             <includes>
                 <include>*.jar</include>
             </includes>
@@ -38,7 +38,7 @@
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/src/main/assembly/dist/bin</directory>
-            <outputDirectory>/bin</outputDirectory>
+            <outputDirectory>bin</outputDirectory>
             <includes>
                 <include>*.sh</include>
             </includes>
@@ -46,14 +46,14 @@
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/src/main/resources</directory>
-            <outputDirectory>/cfg</outputDirectory>
+            <outputDirectory>cfg</outputDirectory>
             <includes>
                 <include>default-logback-conf.xml</include>
             </includes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/src/main/assembly/dist</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
             <excludes>
                 <exclude>/bin</exclude>
             </excludes>

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,5 +1,5 @@
-deposit.permissions.access={{ easy_split_multi_deposit_permissions_access }}
-deposit.permissions.group={{ easy_split_multi_deposit_permissions_group }}
+deposit.permissions.access={{ easy_split_multi_deposit_output_permissions }}
+deposit.permissions.group={{ easy_split_multi_deposit_output_group }}
 springfield-inbox={{ easy_split_multi_deposit_springfield_inbox }}
 auth.ldap.url={{ easy_split_multi_deposit_auth_ldap_url }}
 auth.ldap.user={{ easy_split_multi_deposit_ldapadmin_username }}

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,3 +1,4 @@
+deposit.permissions={{ easy_split_multi_deposit_permissions }}
 springfield-inbox={{ easy_split_multi_deposit_springfield_inbox }}
 auth.ldap.url={{ easy_split_multi_deposit_auth_ldap_url }}
 auth.ldap.user={{ easy_split_multi_deposit_ldapadmin_username }}

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,4 +1,5 @@
-deposit.permissions={{ easy_split_multi_deposit_permissions }}
+deposit.permissions.access={{ easy_split_multi_deposit_permissions_access }}
+deposit.permissions.group={{ easy_split_multi_deposit_permissions_group }}
 springfield-inbox={{ easy_split_multi_deposit_springfield_inbox }}
 auth.ldap.url={{ easy_split_multi_deposit_auth_ldap_url }}
 auth.ldap.user={{ easy_split_multi_deposit_ldapadmin_username }}

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
@@ -44,7 +44,7 @@ object CommandLineOptions extends DebugEnhancedLogging {
       springfieldInbox = opts.springfieldInbox(),
       outputDepositDir = opts.outputDepositDir(),
       datamanager = opts.datamanager(),
-      depositPermissions = props.getString("deposit.permissions"),
+      depositPermissions = DepositPermissions(props.getString("deposit.permissions.access"), props.getString("deposit.permissions.group")),
       ldap = {
         val env = new java.util.Hashtable[String, String]
         env.put(Context.PROVIDER_URL, props.getString("auth.ldap.url"))

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
@@ -44,6 +44,7 @@ object CommandLineOptions extends DebugEnhancedLogging {
       springfieldInbox = opts.springfieldInbox(),
       outputDepositDir = opts.outputDepositDir(),
       datamanager = opts.datamanager(),
+      depositPermissions = props.getString("deposit.permissions"),
       ldap = {
         val env = new java.util.Hashtable[String, String]
         env.put(Context.PROVIDER_URL, props.getString("auth.ldap.url"))

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
@@ -64,7 +64,8 @@ object Main extends DebugEnhancedLogging {
       AddBagToDeposit(row, entry),
       AddDatasetMetadataToDeposit(row, entry),
       AddFileMetadataToDeposit(row, entry),
-      AddPropertiesToDeposit(row, entry)
+      AddPropertiesToDeposit(row, entry),
+      SetDepositPermissions(row, datasetID)
     ) ++ getFileActions(dataset)
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.multideposit.actions
 
 import java.io.{ File, IOException }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
@@ -1,0 +1,59 @@
+package nl.knaw.dans.easy.multideposit.actions
+
+import java.io.{ File, IOException }
+import java.nio.file.attribute.{ BasicFileAttributes, PosixFilePermissions }
+import java.nio.file.{ FileVisitResult, Files, Path, SimpleFileVisitor }
+
+import nl.knaw.dans.easy.multideposit.{ Action, DatasetID, _ }
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+
+import scala.util.control.NonFatal
+import scala.util.{ Failure, Success, Try }
+
+// TODO add the 'move to easy-ingest-flow inbox' functionality in this class
+// TODO rename this file accordingly
+case class SetDepositPermissions(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action {
+
+  def execute(): Try[Unit] = {
+    setFilePermissions().recoverWith {
+      case NonFatal(e) => Failure(ActionException(row, e.getMessage, e))
+    }
+  }
+
+  private def setFilePermissions(): Try[Unit] = {
+    val depositDir = outputDepositDir(datasetID)
+    isOnPosixFileSystem(depositDir)
+      .flatMap {
+        case true => Try { Files.walkFileTree(depositDir.toPath, PermissionFileVisitor(settings.depositPermissions)) }
+        case false => Success(())
+      }
+  }
+
+  private def isOnPosixFileSystem(file: File): Try[Boolean] = Try {
+    Files.getPosixFilePermissions(file.toPath)
+    true
+  } recover {
+    case _: UnsupportedOperationException => false
+  }
+
+  private case class PermissionFileVisitor(permissions: String) extends SimpleFileVisitor[Path] with DebugEnhancedLogging {
+    override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
+      Try {
+        Files.setPosixFilePermissions(path, PosixFilePermissions.fromString(permissions))
+        FileVisitResult.CONTINUE
+      } onError {
+        case usoe: UnsupportedOperationException => logger.error("Not on a POSIX supported file system", usoe); FileVisitResult.TERMINATE
+        case cce: ClassCastException => logger.error("Non file permission elements in set", cce); FileVisitResult.TERMINATE
+        case ioe: IOException => logger.error(s"Could not set file permissions on $path", ioe); FileVisitResult.TERMINATE
+        case se: SecurityException => logger.error(s"Not enough privileges to set file permissions on $path", se); FileVisitResult.TERMINATE
+        case NonFatal(e) => logger.error("unexpected error occured", e); FileVisitResult.TERMINATE
+      }
+    }
+
+    override def postVisitDirectory(dir: Path, exception: IOException): FileVisitResult = {
+      Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString(permissions))
+      if (exception == null) FileVisitResult.CONTINUE
+      else FileVisitResult.TERMINATE
+    }
+  }
+}

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
@@ -58,7 +58,7 @@ case class SetDepositPermissions(row: Int, datasetID: DatasetID)(implicit settin
         FileVisitResult.CONTINUE
       } onError {
         case usoe: UnsupportedOperationException => logger.error("Not on a POSIX supported file system", usoe); FileVisitResult.TERMINATE
-        case cce: ClassCastException => logger.error("Non file permission elements in set", cce); FileVisitResult.TERMINATE
+        case cce: ClassCastException => logger.error("No file permission elements in set", cce); FileVisitResult.TERMINATE
         case iae: IllegalArgumentException => logger.error(s"Invalid privileges ($permissions)", iae); FileVisitResult.TERMINATE
         case ioe: IOException => logger.error(s"Could not set file permissions on $path", ioe); FileVisitResult.TERMINATE
         case se: SecurityException => logger.error(s"Not enough privileges to set file permissions on $path", se); FileVisitResult.TERMINATE

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
@@ -44,9 +44,10 @@ case class SetDepositPermissions(row: Int, datasetID: DatasetID)(implicit settin
       } onError {
         case usoe: UnsupportedOperationException => logger.error("Not on a POSIX supported file system", usoe); FileVisitResult.TERMINATE
         case cce: ClassCastException => logger.error("Non file permission elements in set", cce); FileVisitResult.TERMINATE
+        case iae: IllegalArgumentException => logger.error(s"Invalid privileges ($permissions)", iae); FileVisitResult.TERMINATE
         case ioe: IOException => logger.error(s"Could not set file permissions on $path", ioe); FileVisitResult.TERMINATE
         case se: SecurityException => logger.error(s"Not enough privileges to set file permissions on $path", se); FileVisitResult.TERMINATE
-        case NonFatal(e) => logger.error("unexpected error occured", e); FileVisitResult.TERMINATE
+        case NonFatal(e) => logger.error(s"unexpected error occured on $path", e); FileVisitResult.TERMINATE
       }
     }
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
@@ -43,11 +43,12 @@ package object multideposit {
   case class FileParameters(row: Option[Int], sip: Option[String], dataset: Option[String],
                             storageService: Option[String], storagePath: Option[String],
                             audioVideo: Option[String])
+  case class DepositPermissions(permissions: String, group: String)
   case class Settings(multidepositDir: File = null,
                       springfieldInbox: File = null,
                       outputDepositDir: File = null,
                       datamanager: String = null,
-                      depositPermissions: String = null,
+                      depositPermissions: DepositPermissions = null,
                       ldap: Ldap = null) {
     override def toString: String =
       s"Settings(multideposit-dir=$multidepositDir, " +

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
@@ -47,6 +47,7 @@ package object multideposit {
                       springfieldInbox: File = null,
                       outputDepositDir: File = null,
                       datamanager: String = null,
+                      depositPermissions: String = null,
                       ldap: Ldap = null) {
     override def toString: String =
       s"Settings(multideposit-dir=$multidepositDir, " +

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,4 +1,5 @@
-deposit.permissions=rwxrwx---
+deposit.permissions.access=rwxrwx---
+deposit.permissions.group=admin
 springfield-inbox=data/springfield-inbox
 auth.ldap.url=ldap://deasy.dans.knaw.nl
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,4 +1,4 @@
-deposit.permissions="rwxrwx---"
+deposit.permissions=rwxrwx---
 springfield-inbox=data/springfield-inbox
 auth.ldap.url=ldap://deasy.dans.knaw.nl
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,3 +1,4 @@
+deposit.permissions="rwxrwx---"
 springfield-inbox=data/springfield-inbox
 auth.ldap.url=ldap://deasy.dans.knaw.nl
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/CustomMatchers.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/CustomMatchers.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/MainSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/MainSpec.scala
@@ -39,7 +39,8 @@ class MainSpec extends UnitSpec {
       AddBagToDeposit(2, entry),
       AddDatasetMetadataToDeposit(2, entry),
       AddFileMetadataToDeposit(2, entry),
-      AddPropertiesToDeposit(2, entry))
+      AddPropertiesToDeposit(2, entry),
+      SetDepositPermissions(2, datasetID))
     val fileActions = Seq(CopyToSpringfieldInbox(2, "videos/centaur.mpg"))
   }
 
@@ -50,13 +51,14 @@ class MainSpec extends UnitSpec {
       AddBagToDeposit(2, entry),
       AddDatasetMetadataToDeposit(2, entry),
       AddFileMetadataToDeposit(2, entry),
-      AddPropertiesToDeposit(2, entry))
+      AddPropertiesToDeposit(2, entry),
+      SetDepositPermissions(2, datasetID))
     val fileActions = Seq(CopyToSpringfieldInbox(4, "videos/centaur.mpg"))
   }
 
   "getActions" should "return all actions to be performed given the collection of datasets" in {
     getActions(testDatasets) should {
-      have size 13 and
+      have size 15 and
       contain theSameElementsInOrderAs(
         dataset1Actions.datasetActions ++ dataset1Actions.fileActions ++
         dataset2Actions.datasetActions ++ dataset2Actions.fileActions ++
@@ -74,14 +76,14 @@ class MainSpec extends UnitSpec {
   "getDatasetActions" should "return a collection of actions for the given dataset" in {
     import dataset1Actions._
     getDatasetActions(entry) should {
-      have size 6 and contain theSameElementsInOrderAs (datasetActions ++ fileActions)
+      have size 7 and contain theSameElementsInOrderAs (datasetActions ++ fileActions)
     }
   }
 
   it should "do the same for testDataset2" in {
     import dataset2Actions._
     getDatasetActions(entry) should {
-      have size 6 and contain theSameElementsInOrderAs (datasetActions ++ fileActions)
+      have size 7 and contain theSameElementsInOrderAs (datasetActions ++ fileActions)
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -16,15 +16,15 @@
 package nl.knaw.dans.easy.multideposit.actions
 
 import java.io.File
-import javax.naming.directory.{Attributes, BasicAttribute, BasicAttributes}
+import javax.naming.directory.{ Attributes, BasicAttribute, BasicAttributes }
 
-import nl.knaw.dans.easy.multideposit.{ActionException, Settings, UnitSpec, _}
+import nl.knaw.dans.easy.multideposit.{ ActionException, Settings, UnitSpec, _ }
 import nl.knaw.dans.lib.error.CompositeException
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, PrivateMethodTester}
+import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, PrivateMethodTester }
 
 import scala.collection.mutable
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success }
 
 class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with BeforeAndAfterAll with MockFactory with PrivateMethodTester {
 
@@ -40,7 +40,7 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with Befor
     "DEPOSITOR_ID" -> List("dp1", "", "", "")
   )
 
-  val correctDatamanagerAttrs = createDatamanagerAttributes()
+  private val correctDatamanagerAttrs = createDatamanagerAttributes()
 
   /**
    * Default creates correct BasicAttributes

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissionsSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.multideposit.actions
 
 import java.io.File

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissionsSpec.scala
@@ -34,10 +34,6 @@ class SetDepositPermissionsSpec extends UnitSpec with BeforeAndAfter with Before
     val allGroups = "cut -d: -f1 /etc/group".!!.split("\n").filterNot(_ startsWith "#").toList
     val userGroups = s"id -Gn $user".!!.split(" ").toList
 
-    println(s"user: $user")
-    println(s"all groups: $allGroups")
-    println(s"user groups: $userGroups")
-
     (user, userGroups.head, allGroups.diff(userGroups).head)
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissionsSpec.scala
@@ -1,0 +1,73 @@
+package nl.knaw.dans.easy.multideposit.actions
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+
+import nl.knaw.dans.easy.multideposit.{ Settings, UnitSpec, _ }
+import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll }
+
+import scala.util.Success
+
+class SetDepositPermissionsSpec extends UnitSpec with BeforeAndAfter with BeforeAndAfterAll {
+
+  implicit val settings = Settings(
+    multidepositDir = new File(testDir, "md"),
+    outputDepositDir = new File(testDir, "dd"),
+    depositPermissions = "rwxrwx---"
+  )
+
+  private val datasetID = "ruimtereis01"
+
+  private val base = outputDepositDir(datasetID)
+  private val folder1 = new File(base, "folder1")
+  private val folder2 = new File(base, "folder2")
+  private val file1 = new File(base, "file1.txt")
+  private val file2 = new File(folder1, "file2.txt")
+  private val file3 = new File(folder1, "file3.txt")
+  private val file4 = new File(folder2, "file4.txt")
+  private val filesAndFolders = List(base, folder1, folder2, file1, file2, file3, file4)
+
+  before {
+    base.mkdirs()
+    folder1.mkdirs()
+    folder2.mkdirs()
+
+    file1.write("abcdef")
+    file2.write("defghi")
+    file3.write("ghijkl")
+    file4.write("jklmno")
+
+    for (file <- filesAndFolders) {
+      file shouldBe readable
+      file shouldBe writable
+    }
+  }
+
+  after {
+    base.deleteDirectory()
+  }
+
+  override def afterAll: Unit = testDir.getParentFile.deleteDirectory()
+
+  "setFilePermissions" should "set the permissions of each of the files and folders to the correct permissions" in {
+    SetDepositPermissions(1, datasetID).execute() shouldBe a[Success[_]]
+
+    for (file <- filesAndFolders) {
+      Files.getPosixFilePermissions(file.toPath) should {
+        have size 6 and contain only(
+          PosixFilePermission.OWNER_READ,
+          PosixFilePermission.OWNER_WRITE,
+          PosixFilePermission.OWNER_EXECUTE,
+          PosixFilePermission.GROUP_READ,
+          PosixFilePermission.GROUP_WRITE,
+          PosixFilePermission.GROUP_EXECUTE
+        ) and contain noneOf(
+          PosixFilePermission.OTHERS_READ,
+          PosixFilePermission.OTHERS_WRITE,
+          PosixFilePermission.OTHERS_EXECUTE
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
fixes EASY-1225

#### When applied it will
* [x] make sure the deposit permissions are set to `rwxrwx---`
* [x] fix some IntelliJ warnings
* [x] fix a bug with `mvn license:format`
* [x] upgrade the parent pom to 1.42 and change the `bin.xml` accordingly
* [x] be tested

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-ingest-flow                      | [PR#9](https://github.com/DANS-KNAW/easy-ingest-flow/pull/9) 
easy-dtap | [PR#80](https://github.com/DANS-KNAW/easy-dtap/pull/80)
