### PR TITLE
Easy 1178: create deposit in staging directory, then move it to the output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ ARGUMENTS
                                      'staging-dir' in 'application.properties' is used. (default = data/staging)
         --help                       Show help message
         --version                    Show version of this program
-  
+
    trailing arguments:
     multi-deposit-dir (required)   Directory containing the Submission Information Package to process. This must
                                    be a valid path to a directory containing a file named 'instructions.csv' in

--- a/README.md
+++ b/README.md
@@ -43,22 +43,26 @@ ARGUMENTS
 ```
   Usage: 
 
-      easy-split-multi-deposit.sh [{--springfield-inbox|-s} <dir>] <multi-deposit-dir> <output-deposits-dir> <datamanager>
+      easy-split-multi-deposit.sh [{--springfield-inbox|-s} <dir>] [{--staging-dir|-d} <dir>] <multi-deposit-dir> <output-deposits-dir> <datamanager>
 
   Options:
 
     -s, --springfield-inbox  <arg>   The inbox directory of a Springfield Streaming Media Platform installation.
-                                     If not specified the value of springfield-inbox in application.properties
-                                     is used. (default = data/springfield-inbox)
+                                     If not specified the value of 'springfield-inbox' in
+                                     'application.properties' is used. (default = data/springfield-inbox)
+    -d, --staging-dir  <arg>         A directory in which the deposit directories are created, after which they
+                                     will be moved to the 'deposit-dir'. If not specified, the value of
+                                     'staging-dir' in 'application.properties' is used. (default = data/staging)
         --help                       Show help message
         --version                    Show version of this program
-
+  
    trailing arguments:
     multi-deposit-dir (required)   Directory containing the Submission Information Package to process. This must
                                    be a valid path to a directory containing a file named 'instructions.csv' in
                                    RFC4180 format.
-    deposit-dir (required)         A directory in which the deposit directories must be created. The deposit
-                                   directory layout is described in the easy-sword2 documentation
+    deposit-dir (required)         A directory to which the deposit directories are moved after the staging has
+                                   been completed successfully. The deposit directory layout is described in the
+                                   easy-sword2 documentation
     datamanager (required)         The username (id) of the datamanger (archivist) performing this deposit
 ```
 

--- a/debug-reset-apphome.sh
+++ b/debug-reset-apphome.sh
@@ -35,6 +35,7 @@ cp -r src/test/resources/sip001 $TEMPDIR/input/sip001
 cp -r src/test/resources/spacetravel $TEMPDIR/input/spacetravel
 mkdir $TEMPDIR/output/
 mkdir $TEMPDIR/springfield-inbox
+mkdir $TEMPDIR/staging
 chmod -R 777 $TEMPDIR
 
 echo "A fresh application home directory for debugging has been set up at $APPHOME"

--- a/run.sh
+++ b/run.sh
@@ -36,6 +36,13 @@ if [[ " ${ARGS[*]} " != *"--help"* ]] && [[ " ${ARGS[*]} " != *"--version"* ]]; 
         mkdir $SPRINGFIELD
         echo "the old springfield-inbox folder has been moved to $NEWSPRINGFIELD"
     fi
+
+    if [ "$(ls -A $STAGING)" ]; then
+        NEWSTAGING=$STAGING-`date  +"%Y-%m-%d@%H:%M:%S"`
+        mv $STAGING $NEWSTAGING
+        mkdir $STAGING
+        echo "the old staging folder has been moved to $NEWSTAGING"
+    fi
 fi
 
 mvn exec:java -Dapp.home=$APPHOME \

--- a/run.sh
+++ b/run.sh
@@ -22,18 +22,20 @@ OUTPUT=data/output
 SPRINGFIELD=data/springfield-inbox
 STAGING=data/staging
 
-if [ "$(ls -A $OUTPUT)" ]; then
-    NEWOUTPUT=$OUTPUT-`date  +"%Y-%m-%d@%H:%M:%S"`
-    mv $OUTPUT $NEWOUTPUT
-    mkdir $OUTPUT
-    echo "the old output folder has been moved to $NEWOUTPUT"
-fi
+if [[ " ${ARGS[*]} " != *"--help"* ]] && [[ " ${ARGS[*]} " != *"--version"* ]]; then
+    if [ "$(ls -A $OUTPUT)" ]; then
+        NEWOUTPUT=$OUTPUT-`date  +"%Y-%m-%d@%H:%M:%S"`
+        mv $OUTPUT $NEWOUTPUT
+        mkdir $OUTPUT
+        echo "the old output folder has been moved to $NEWOUTPUT"
+    fi
 
-if [ "$(ls -A $SPRINGFIELD)" ]; then
-    NEWSPRINGFIELD=$SPRINGFIELD-`date  +"%Y-%m-%d@%H:%M:%S"`
-    mv $SPRINGFIELD $NEWSPRINGFIELD
-    mkdir $SPRINGFIELD
-    echo "the old springfield-inbox folder has been moved to $NEWSPRINGFIELD"
+    if [ "$(ls -A $SPRINGFIELD)" ]; then
+        NEWSPRINGFIELD=$SPRINGFIELD-`date  +"%Y-%m-%d@%H:%M:%S"`
+        mv $SPRINGFIELD $NEWSPRINGFIELD
+        mkdir $SPRINGFIELD
+        echo "the old springfield-inbox folder has been moved to $NEWSPRINGFIELD"
+    fi
 fi
 
 mvn exec:java -Dapp.home=$APPHOME \

--- a/run.sh
+++ b/run.sh
@@ -18,7 +18,23 @@
 
 ARGS=$@
 APPHOME=home
-. apphome.sh
+OUTPUT=data/output
+SPRINGFIELD=data/springfield-inbox
+STAGING=data/staging
+
+if [ "$(ls -A $OUTPUT)" ]; then
+    NEWOUTPUT=$OUTPUT-`date  +"%Y-%m-%d@%H:%M:%S"`
+    mv $OUTPUT $NEWOUTPUT
+    mkdir $OUTPUT
+    echo "the old output folder has been moved to $NEWOUTPUT"
+fi
+
+if [ "$(ls -A $SPRINGFIELD)" ]; then
+    NEWSPRINGFIELD=$SPRINGFIELD-`date  +"%Y-%m-%d@%H:%M:%S"`
+    mv $SPRINGFIELD $NEWSPRINGFIELD
+    mkdir $SPRINGFIELD
+    echo "the old springfield-inbox folder has been moved to $NEWSPRINGFIELD"
+fi
 
 mvn exec:java -Dapp.home=$APPHOME \
               -Dlogback.configurationFile=$APPHOME/cfg/logback.xml \

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,6 +1,7 @@
 deposit.permissions.access={{ easy_split_multi_deposit_output_permissions }}
 deposit.permissions.group={{ easy_split_multi_deposit_output_group }}
 springfield-inbox={{ easy_split_multi_deposit_springfield_inbox }}
+staging-dir={{ easy_split_multi_deposit_staging_dir }}
 auth.ldap.url={{ easy_split_multi_deposit_auth_ldap_url }}
 auth.ldap.user={{ easy_split_multi_deposit_ldapadmin_username }}
 auth.ldap.password={{ easy_split_multi_deposit_ldapadmin_password }}

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
@@ -42,6 +42,7 @@ object CommandLineOptions extends DebugEnhancedLogging {
     val settings = Settings(
       multidepositDir = opts.multiDepositDir(),
       springfieldInbox = opts.springfieldInbox(),
+      stagingDir = opts.stagingDir(),
       outputDepositDir = opts.outputDepositDir(),
       datamanager = opts.datamanager(),
       depositPermissions = DepositPermissions(props.getString("deposit.permissions.access"), props.getString("deposit.permissions.group")),
@@ -119,7 +120,7 @@ class ScallopCommandLine(props: PropertiesConfiguration, args: Array[String]) ex
   validateFileExists(multiDepositDir)
   validateFileIsDirectory(multiDepositDir)
   validate(multiDepositDir)(dir => {
-    val instructionFile: File = new File(dir, instructionsFileName)
+    val instructionFile: File = multiDepositInstructionsFile(dir)
     if (!dir.directoryContains(instructionFile))
       Left(s"No instructions file found in this directory, expected: $instructionFile")
     else

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
@@ -70,7 +70,7 @@ class ScallopCommandLine(props: PropertiesConfiguration, args: Array[String]) ex
   printedName = "easy-split-multi-deposit"
   version(s"$printedName ${Version()}")
   val description = "Splits a Multi-Deposit into several deposit directories for subsequent ingest into the archive"
-  val synopsis = s"""$printedName.sh [{--springfield-inbox|-s} <dir>] <multi-deposit-dir> <output-deposits-dir> <datamanager>"""
+  val synopsis = s"""$printedName.sh [{--springfield-inbox|-s} <dir>] [{--staging-dir|-d} <dir>] <multi-deposit-dir> <output-deposits-dir> <datamanager>"""
   banner(s"""
            |  $description
            |  Utility to process a Multi-Deposit prior to ingestion into the DANS EASY Archive
@@ -91,15 +91,25 @@ class ScallopCommandLine(props: PropertiesConfiguration, args: Array[String]) ex
 
   val springfieldInbox: ScallopOption[File] = opt[File](
     name = "springfield-inbox",
+    short = 's',
     descr = "The inbox directory of a Springfield Streaming Media Platform installation. " +
-      "If not specified the value of springfield-inbox in application.properties is used.",
+      "If not specified the value of 'springfield-inbox' in 'application.properties' is used.",
     default = Some(new File(props.getString("springfield-inbox"))))
+
+  val stagingDir: ScallopOption[File] = opt[File](
+    name = "staging-dir",
+    short = 'd', // TODO make this 's' once the springfieldInbox argument has been removed
+    descr = "A directory in which the deposit directories are created, after which they will be " +
+      "moved to the 'deposit-dir'. If not specified, the value of 'staging-dir' in " +
+      "'application.properties' is used.",
+    default = Some(new File(props.getString("staging-dir"))))
 
   val outputDepositDir: ScallopOption[File] = trailArg[File](
     name = "deposit-dir",
     required = true,
-    descr = "A directory in which the deposit directories must be created. "
-      + "The deposit directory layout is described in the easy-sword2 documentation")
+    descr = "A directory to which the deposit directories are moved after the staging has been " +
+      "completed successfully. The deposit directory layout is described in the easy-sword2 " +
+      "documentation")
 
   val datamanager: ScallopOption[String] = trailArg[String](
     name = "datamanager",

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/CommandLineOptions.scala
@@ -130,5 +130,8 @@ class ScallopCommandLine(props: PropertiesConfiguration, args: Array[String]) ex
   validateFileExists(springfieldInbox)
   validateFileIsDirectory(springfieldInbox)
 
+  validateFileExists(outputDepositDir)
+  validateFileIsDirectory(outputDepositDir)
+
   verify()
 }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
@@ -60,7 +60,7 @@ object Main extends DebugEnhancedLogging {
     logger.debug(s"Getting actions for dataset $datasetID ...")
 
     Seq(
-      CreateOutputDepositDir(row, datasetID),
+      CreateStagingDir(row, datasetID),
       AddBagToDeposit(row, entry),
       AddDatasetMetadataToDeposit(row, entry),
       AddFileMetadataToDeposit(row, entry),

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
@@ -50,12 +50,13 @@ object Main extends DebugEnhancedLogging {
   }
 
   def getGeneralActions(datasets: Datasets)(implicit settings: Settings): Seq[Action] = {
-    Seq(CreateSpringfieldActions(-1, datasets))
+    Seq(CreateSpringfieldActions(-1, datasets)) ++
+      datasets.map { case (datasetID, dataset) => MoveDepositToOutputDir(dataset.getRowNumber, datasetID) }
   }
 
   def getDatasetActions(entry: (DatasetID, Dataset))(implicit settings: Settings): Seq[Action] = {
     val (datasetID, dataset) = entry
-    val row = dataset("ROW").head.toInt // first occurrence of dataset, assuming it is not empty
+    val row = dataset.getRowNumber
 
     logger.debug(s"Getting actions for dataset $datasetID ...")
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddBagToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddBagToDeposit.scala
@@ -49,7 +49,7 @@ object AddBagToDeposit {
   def createBag(datasetID: DatasetID, dataset: Dataset)(implicit settings: Settings): Try[Unit] = Try {
     val inputDir = multiDepositDir(datasetID)
     val inputDirExists = inputDir.exists
-    val outputBagDir = outputDepositBagDir(datasetID)
+    val outputBagDir = stagingBagDir(datasetID)
 
     val bagFactory = new BagFactory
     val preBag = bagFactory.createPreBag(outputBagDir)

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -103,7 +103,7 @@ object AddDatasetMetadataToDeposit {
 
   def writeDatasetMetadataXml(row: Int, datasetID: DatasetID, dataset: Dataset)(implicit settings: Settings): Try[Unit] = {
     Try {
-      outputDatasetMetadataFile(datasetID).writeXml(datasetToXml(dataset))
+      stagingDatasetMetadataFile(datasetID).writeXml(datasetToXml(dataset))
     } recoverWith {
       case NonFatal(e) => Failure(ActionException(row, s"Could not write dataset metadata: $e", e))
     }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
@@ -53,7 +53,7 @@ object AddFileMetadataToDeposit {
 
   def writeFileMetadataXml(row: Int, datasetID: DatasetID)(implicit settings: Settings): Try[Unit] = {
     datasetToFileXml(datasetID)
-      .map(outputFileMetadataFile(datasetID).writeXml(_))
+      .map(stagingFileMetadataFile(datasetID).writeXml(_))
       .recoverWith {
         case NonFatal(e) => Failure(ActionException(row, s"Could not write file meta data: $e", e))
       }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDeposit.scala
@@ -121,7 +121,7 @@ object AddPropertiesToDeposit {
     }
 
     addProperties(props, dataset, settings.datamanager, emailaddress)
-      .flatMap(_ => Using.fileWriter(encoding)(outputPropertiesFile(datasetID)).map(out => props.store(out, "")).tried)
+      .flatMap(_ => Using.fileWriter(encoding)(stagingPropertiesFile(datasetID)).map(out => props.store(out, "")).tried)
       .recoverWith {
         case NonFatal(e) => Failure(ActionException(row, s"Could not write properties to file: $e", e))
       }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CopyToSpringfieldInbox.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CopyToSpringfieldInbox.scala
@@ -22,17 +22,17 @@ import scala.util.{ Failure, Success, Try }
 
 case class CopyToSpringfieldInbox(row: Int, fileMd: String)(implicit settings: Settings) extends Action {
 
-  private val mdFile = multiDepositDir(fileMd)
+  private val mdDir = multiDepositDir(fileMd)
 
   override def checkPreconditions: Try[Unit] = {
-    if (mdFile.exists) Success(Unit)
-    else Failure(ActionException(row, s"Cannot find MD file: ${ mdFile.getPath }"))
+    if (mdDir.exists) Success(Unit)
+    else Failure(ActionException(row, s"Cannot find ${ mdDir.getPath }"))
   }
 
   override def execute(): Try[Unit] = {
     val sfFile = springfieldInboxDir(fileMd)
-    Try { mdFile.copyFile(sfFile) } recoverWith {
-      case NonFatal(e) => Failure(ActionException(row, s"Error in copying $mdFile to $sfFile: ${ e.getMessage }", e))
+    Try { mdDir.copyFile(sfFile) } recoverWith {
+      case NonFatal(e) => Failure(ActionException(row, s"Error in copying $mdDir to $sfFile: ${ e.getMessage }", e))
     }
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateOutputDepositDir.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateOutputDepositDir.scala
@@ -22,10 +22,10 @@ import scala.util.{ Failure, Success, Try }
 
 case class CreateOutputDepositDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action {
 
-  private val depositDir = stagingDir(datasetID)
+  private val stagingDirectory = stagingDir(datasetID)
   private val bagDir = stagingBagDir(datasetID)
   private val metadataDir = stagingBagMetadataDir(datasetID)
-  private val dirs = depositDir :: bagDir :: metadataDir :: Nil
+  private val dirs = stagingDirectory :: bagDir :: metadataDir :: Nil
 
   override def checkPreconditions: Try[Unit] = checkDirectoriesDoNotExist
 
@@ -38,12 +38,12 @@ case class CreateOutputDepositDir(row: Int, datasetID: DatasetID)(implicit setti
   override def execute(): Try[Unit] = {
     debug(s"making directories: $dirs")
     if (dirs.forall(_.mkdirs)) Success(())
-    else Failure(ActionException(row, s"Could not create the dataset output deposit directory at $depositDir"))
+    else Failure(ActionException(row, s"Could not create the staging directory at $stagingDirectory"))
   }
 
   override def rollback(): Try[Unit] = {
-    Try { depositDir.deleteDirectory() } recoverWith {
-      case NonFatal(e) => Failure(ActionException(row, s"Could not delete $depositDir, exception: $e", e))
+    Try { stagingDirectory.deleteDirectory() } recoverWith {
+      case NonFatal(e) => Failure(ActionException(row, s"Could not delete $stagingDirectory, exception: $e", e))
     }
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateOutputDepositDir.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateOutputDepositDir.scala
@@ -22,9 +22,9 @@ import scala.util.{ Failure, Success, Try }
 
 case class CreateOutputDepositDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action {
 
-  private val depositDir = outputDepositDir(datasetID)
-  private val bagDir = outputDepositBagDir(datasetID)
-  private val metadataDir = outputDepositBagMetadataDir(datasetID)
+  private val depositDir = stagingDir(datasetID)
+  private val bagDir = stagingBagDir(datasetID)
+  private val metadataDir = stagingBagMetadataDir(datasetID)
   private val dirs = depositDir :: bagDir :: metadataDir :: Nil
 
   override def checkPreconditions: Try[Unit] = checkDirectoriesDoNotExist

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateStagingDir.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateStagingDir.scala
@@ -20,7 +20,7 @@ import nl.knaw.dans.easy.multideposit._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-case class CreateOutputDepositDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action {
+case class CreateStagingDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action {
 
   private val stagingDirectory = stagingDir(datasetID)
   private val bagDir = stagingBagDir(datasetID)

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/MoveDepositToOutputDir.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/MoveDepositToOutputDir.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.multideposit.actions
 
 import nl.knaw.dans.easy.multideposit.{ Action, DatasetID, Settings, _ }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/MoveDepositToOutputDir.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/MoveDepositToOutputDir.scala
@@ -1,0 +1,37 @@
+package nl.knaw.dans.easy.multideposit.actions
+
+import nl.knaw.dans.easy.multideposit.{ Action, DatasetID, Settings, _ }
+
+import scala.util.control.NonFatal
+import scala.util.{ Failure, Success, Try }
+
+case class MoveDepositToOutputDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action {
+
+  private val outputDir = outputDepositDir(datasetID)
+
+  override def checkPreconditions: Try[Unit] = {
+    Try { outputDir.exists() }
+      .flatMap {
+        case true => Failure(ActionException(row, s"The deposit for dataset $datasetID already exists in $outputDir"))
+        case false => Success(())
+      }
+  }
+
+  def execute(): Try[Unit] = {
+    val stagingDirectory = stagingDir(datasetID)
+
+    debug(s"moving $stagingDirectory to $outputDir")
+
+    Try { stagingDirectory.moveDir(outputDir) } recover {
+      case NonFatal(e) => println(s"An error occurred while moving $stagingDirectory to " +
+        s"$outputDir: ${e.getMessage}. This move is NOT revertable! When in doubt, contact your " +
+        s"application manager.", e)
+    }
+  }
+
+  // Moves from staging to output only happen when all deposit creations have completed successfully.
+  // These moves are not revertable, since they (depending on configuration) will be moved to the
+  // easy-ingest-flow inbox, which might have started processing the first deposit when a second
+  // move fails. At this point the application manager needs to take a look at what happened and why
+  // the deposits where not able to be moved.
+}

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
@@ -38,10 +38,10 @@ case class SetDepositPermissions(row: Int, datasetID: DatasetID)(implicit settin
   }
 
   private def setFilePermissions(): Try[Unit] = {
-    val depositDir = stagingDir(datasetID)
-    isOnPosixFileSystem(depositDir)
+    val stagingDirectory = stagingDir(datasetID)
+    isOnPosixFileSystem(stagingDirectory)
       .flatMap {
-        case true => Try { Files.walkFileTree(depositDir.toPath, PermissionFileVisitor(settings.depositPermissions)) }
+        case true => Try { Files.walkFileTree(stagingDirectory.toPath, PermissionFileVisitor(settings.depositPermissions)) }
         case false => Success(())
       }
   }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
@@ -26,8 +26,6 @@ import scala.language.postfixOps
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-// TODO add the 'move to easy-ingest-flow inbox' functionality in this class
-// TODO rename this file accordingly
 case class SetDepositPermissions(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action {
 
   def execute(): Try[Unit] = {

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
@@ -38,7 +38,7 @@ case class SetDepositPermissions(row: Int, datasetID: DatasetID)(implicit settin
   }
 
   private def setFilePermissions(): Try[Unit] = {
-    val depositDir = outputDepositDir(datasetID)
+    val depositDir = stagingDir(datasetID)
     isOnPosixFileSystem(depositDir)
       .flatMap {
         case true => Try { Files.walkFileTree(depositDir.toPath, PermissionFileVisitor(settings.depositPermissions)) }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
@@ -15,19 +15,19 @@
  */
 package nl.knaw.dans.easy
 
-import java.io.{File, IOException}
+import java.io.{ File, IOException }
 import java.nio.charset.Charset
 import java.util.Properties
 
-import org.apache.commons.io.{Charsets, FileUtils}
+import org.apache.commons.io.{ Charsets, FileExistsException, FileUtils }
 import org.apache.commons.lang.StringUtils
 
 import scala.collection.JavaConversions.collectionAsScalaIterable
 import scala.collection.immutable.IndexedSeq
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import scala.util.{Failure, Success, Try}
-import scala.xml.{Elem, PrettyPrinter}
+import scala.util.{ Failure, Success, Try }
+import scala.xml.{ Elem, PrettyPrinter }
 
 package object multideposit {
 
@@ -148,7 +148,7 @@ package object multideposit {
      *
      * @param data the content to write to the file
      */
-    @throws(classOf[IOException])
+    @throws[IOException]("in case of an I/O error")
     def write(data: String, encoding: Charset = encoding): Unit = FileUtils.write(file, data, encoding)
 
     /**
@@ -157,6 +157,7 @@ package object multideposit {
      * @param elem the xml to be written
      * @param encoding the encoding applied to this xml
      */
+    @throws[IOException]("in case of an I/O error")
     def writeXml(elem: Elem, encoding: Charset = encoding): Unit = {
       val header = s"""<?xml version="1.0" encoding="$encoding"?>\n"""
       val data = new PrettyPrinter(160, 2).format(elem)
@@ -169,7 +170,7 @@ package object multideposit {
      *
      * @param data the content to write to the file
      */
-    @throws(classOf[IOException])
+    @throws[IOException]("in case of an I/O error")
     def append(data: String): Unit = FileUtils.write(file, data, true)
 
     /**
@@ -178,7 +179,7 @@ package object multideposit {
      *
      * @return the file contents, never ``null``
      */
-    @throws(classOf[IOException])
+    @throws[IOException]("in case of an I/O error")
     def read(encoding: Charset = encoding): String = FileUtils.readFileToString(file, encoding)
 
     /**
@@ -198,7 +199,7 @@ package object multideposit {
      * @param child the file to consider as the child.
      * @return true is the candidate leaf is under by the specified composite. False otherwise.
      */
-    @throws(classOf[IOException])
+    @throws[IOException]("if an IO error occurs while checking the files.")
     def directoryContains(child: File): Boolean = FileUtils.directoryContains(file, child)
 
     /**
@@ -219,8 +220,9 @@ package object multideposit {
      *
      * @param destDir the new directory, must not be ``null``
      */
-    @throws(classOf[NullPointerException])
-    @throws(classOf[IOException])
+    @throws[NullPointerException]("if source or destination is null")
+    @throws[IOException]("if source or destination is invalid")
+    @throws[IOException]("if an IO error occurs during copying")
     def copyFile(destDir: File): Unit = FileUtils.copyFile(file, destDir)
 
     /**
@@ -241,11 +243,28 @@ package object multideposit {
      *
      * @param destDir the new directory, must not be ``null``
      */
+    @throws[NullPointerException]("if source or destination is null")
+    @throws[IOException]("if source or destination is invalid")
+    @throws[IOException]("if an IO error occurs during copying")
     def copyDir(destDir: File): Unit = FileUtils.copyDirectory(file, destDir)
+
+    /**
+     * Moves a directory.
+     * <p>
+     * When the destination directory is on another file system, do a "copy and delete".
+     *
+     * @param destDir the destination directory
+     */
+    @throws[NullPointerException]("if source or destination is null")
+    @throws[FileExistsException]("if the destination directory exists")
+    @throws[IOException]("if source or destination is invalid")
+    @throws[IOException]("if an IO error occurs moving the file")
+    def moveDir(destDir: File): Unit = FileUtils.moveDirectory(file, destDir)
 
     /**
      * Deletes a directory recursively.
      */
+    @throws[IOException]("in case deletion is unsuccessful")
     def deleteDirectory(): Unit = FileUtils.deleteDirectory(file)
 
     /**

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
@@ -276,6 +276,10 @@ package object multideposit {
   }
 
   implicit class DatasetExtensions(val dataset: Dataset) extends AnyVal {
+    def getRowNumber: Int = {
+      dataset("ROW").head.toInt // first occurrence of dataset, assuming it is not empty
+    }
+
     /**
      * Retrieves the value of a certain parameter from the dataset on a certain row.
      * If either the key is not present, the specified row does not exist or the value `blank`

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
@@ -46,6 +46,7 @@ package object multideposit {
   case class DepositPermissions(permissions: String, group: String)
   case class Settings(multidepositDir: File = null,
                       springfieldInbox: File = null,
+                      stagingDir: File = null,
                       outputDepositDir: File = null,
                       datamanager: String = null,
                       depositPermissions: DepositPermissions = null,
@@ -53,8 +54,10 @@ package object multideposit {
     override def toString: String =
       s"Settings(multideposit-dir=$multidepositDir, " +
         s"springfield-inbox=$springfieldInbox, " +
-        s"deposit-dir=$outputDepositDir, " +
-        s"datamanager=$datamanager)"
+        s"staging-dir=$stagingDir, " +
+        s"output-deposit-dir=$outputDepositDir" +
+        s"datamanager=$datamanager, " +
+        s"deposit-permissions=$depositPermissions)"
   }
 
   case class EmptyInstructionsFileException(file: File) extends Exception(s"The given instructions file in '$file' is empty")
@@ -339,41 +342,48 @@ package object multideposit {
   val propsFileName = "deposit.properties"
   val springfieldActionsFileName = "springfield-actions.xml"
 
+  private def datasetDir(datasetID: DatasetID)(implicit settings: Settings): String = {
+    s"${settings.multidepositDir.getName}-$datasetID"
+  }
+  def multiDepositInstructionsFile(baseDir: File): File = {
+    new File(baseDir, instructionsFileName)
+  }
+
   // mdDir/datasetID/
   def multiDepositDir(datasetID: DatasetID)(implicit settings: Settings): File = {
     new File(settings.multidepositDir, datasetID)
   }
   // mdDir/instructions.csv
   def multiDepositInstructionsFile(implicit settings: Settings): File = {
-    new File(settings.multidepositDir, instructionsFileName)
+    multiDepositInstructionsFile(settings.multidepositDir)
   }
-  // outDir/mdDir-datasetID/
-  def outputDepositDir(datasetID: DatasetID)(implicit settings: Settings): File = {
-    new File(settings.outputDepositDir, s"${settings.multidepositDir.getName}-$datasetID")
+  // stagingDir/mdDir-datasetID/
+  def stagingDir(datasetID: DatasetID)(implicit settings: Settings): File = {
+    new File(settings.stagingDir, datasetDir(datasetID))
   }
-  // outDir/mdDir-datasetID/bag/
-  def outputDepositBagDir(datasetID: DatasetID)(implicit settings: Settings): File = {
-    new File(outputDepositDir(datasetID), bagDirName)
+  // stagingDir/mdDir-datasetID/bag/
+  def stagingBagDir(datasetID: DatasetID)(implicit settings: Settings): File = {
+    new File(stagingDir(datasetID), bagDirName)
   }
-  // outDir/mdDir-datasetID/bag/data/
-  def outputDepositBagDataDir(datasetID: DatasetID)(implicit settings: Settings): File = {
-    new File(outputDepositBagDir(datasetID), dataDirName)
+  // stagingDir/mdDir-datasetID/bag/data/
+  def stagingBagDataDir(datasetID: DatasetID)(implicit settings: Settings): File = {
+    new File(stagingBagDir(datasetID), dataDirName)
   }
-  // outDir/mdDir-datasetID/bag/metadata/
-  def outputDepositBagMetadataDir(datasetID: DatasetID)(implicit settings: Settings): File = {
-    new File(outputDepositBagDir(datasetID), metadataDirName)
+  // stagingDir/mdDir-datasetID/bag/metadata/
+  def stagingBagMetadataDir(datasetID: DatasetID)(implicit settings: Settings): File = {
+    new File(stagingBagDir(datasetID), metadataDirName)
   }
-  // outDir/mdDir-datasetID/deposit.properties
-  def outputPropertiesFile(datasetID: DatasetID)(implicit settings: Settings): File = {
-    new File(outputDepositDir(datasetID), propsFileName)
+  // stagingDir/mdDir-datasetID/deposit.properties
+  def stagingPropertiesFile(datasetID: DatasetID)(implicit settings: Settings): File = {
+    new File(stagingDir(datasetID), propsFileName)
   }
-  // outDir/mdDir-datasetID/bag/metadata/dataset.xml
-  def outputDatasetMetadataFile(datasetID: DatasetID)(implicit settings: Settings): File = {
-    new File(outputDepositBagMetadataDir(datasetID), datasetMetadataFileName)
+  // stagingDir/mdDir-datasetID/bag/metadata/dataset.xml
+  def stagingDatasetMetadataFile(datasetID: DatasetID)(implicit settings: Settings): File = {
+    new File(stagingBagMetadataDir(datasetID), datasetMetadataFileName)
   }
-  // outDir/mdDir-datasetID/bag/metadata/files.xml
-  def outputFileMetadataFile(datasetID: DatasetID)(implicit settings: Settings): File = {
-    new File(outputDepositBagMetadataDir(datasetID), fileMetadataFileName)
+  // stagingDir/mdDir-datasetID/bag/metadata/files.xml
+  def stagingFileMetadataFile(datasetID: DatasetID)(implicit settings: Settings): File = {
+    new File(stagingBagMetadataDir(datasetID), fileMetadataFileName)
   }
   // sfiDir/<fileMd>
   def springfieldInboxDir(fileMd: String)(implicit settings: Settings): File = {
@@ -382,5 +392,9 @@ package object multideposit {
   // sfiDir/springfield-actions.xml
   def springfieldInboxActionsFile(implicit settings: Settings): File = {
     springfieldInboxDir(springfieldActionsFileName)
+  }
+  // outputDepositDir/mdDir-datasetID/
+  def outputDepositDir(datasetID: DatasetID)(implicit settings: Settings): File = {
+    new File(settings.outputDepositDir, datasetDir(datasetID))
   }
 }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,6 +1,7 @@
 deposit.permissions.access=rwxrwx---
 deposit.permissions.group=admin
 springfield-inbox=data/springfield-inbox
+staging-dir=data/staging
 auth.ldap.url=ldap://deasy.dans.knaw.nl
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=ldapadmin

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/MainSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/MainSpec.scala
@@ -35,7 +35,7 @@ class MainSpec extends UnitSpec {
   val dataset1Actions = new {
     val entry @ (datasetID, dataset) = testDatasets.head
     val datasetActions = Seq(
-      CreateOutputDepositDir(2, datasetID),
+      CreateStagingDir(2, datasetID),
       AddBagToDeposit(2, entry),
       AddDatasetMetadataToDeposit(2, entry),
       AddFileMetadataToDeposit(2, entry),
@@ -47,7 +47,7 @@ class MainSpec extends UnitSpec {
   val dataset2Actions = new {
     val entry @ (datasetID, dataset) = testDatasets.tail.head
     val datasetActions = Seq(
-      CreateOutputDepositDir(2, datasetID),
+      CreateStagingDir(2, datasetID),
       AddBagToDeposit(2, entry),
       AddDatasetMetadataToDeposit(2, entry),
       AddFileMetadataToDeposit(2, entry),

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/MainSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/MainSpec.scala
@@ -30,7 +30,10 @@ class MainSpec extends UnitSpec {
     springfieldInbox = new File(testDir, "sfi")
   )
 
-  val generalActions = Seq(CreateSpringfieldActions(-1, testDatasets))
+  val generalActions = Seq(
+    CreateSpringfieldActions(-1, testDatasets),
+    MoveDepositToOutputDir(2, testDatasets.head._1),
+    MoveDepositToOutputDir(2, testDatasets.tail.head._1))
 
   val dataset1Actions = new {
     val entry @ (datasetID, dataset) = testDatasets.head
@@ -58,7 +61,7 @@ class MainSpec extends UnitSpec {
 
   "getActions" should "return all actions to be performed given the collection of datasets" in {
     getActions(testDatasets) should {
-      have size 15 and
+      have size 17 and
       contain theSameElementsInOrderAs(
         dataset1Actions.datasetActions ++ dataset1Actions.fileActions ++
         dataset2Actions.datasetActions ++ dataset2Actions.fileActions ++
@@ -69,7 +72,7 @@ class MainSpec extends UnitSpec {
 
   "getGeneralActions" should "return a collection of actions that are supposed to run only once for all datasets" in {
     getGeneralActions(testDatasets) should {
-      have size 1 and contain theSameElementsInOrderAs generalActions
+      have size 3 and contain theSameElementsInOrderAs generalActions
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/MainSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/MainSpec.scala
@@ -26,7 +26,7 @@ class MainSpec extends UnitSpec {
 
   implicit val settings = Settings(
     multidepositDir = new File(testDir, "md"),
-    outputDepositDir = new File(testDir, "dd"),
+    stagingDir = new File(testDir, "dd"),
     springfieldInbox = new File(testDir, "sfi")
   )
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ReadmeSpec.scala
@@ -21,13 +21,11 @@ import org.apache.commons.configuration.PropertiesConfiguration
 import org.scalatest._
 
 class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
-  val RES_DIR_STR = new File(getClass.getResource("/").toURI).getAbsolutePath
+  private val RES_DIR_STR: String = new File(getClass.getResource("/").toURI).getAbsolutePath
 
-  val mockedProps = {
-    val ps = new PropertiesConfiguration()
-    ps.setDelimiterParsingDisabled(true)
-    ps.load(new File(RES_DIR_STR + "/debug-config", "application.properties"))
-    ps
+  private val mockedProps = new PropertiesConfiguration() {
+    setDelimiterParsingDisabled(true)
+    load(new File(RES_DIR_STR + "/debug-config", "application.properties"))
   }
 
   val mockedArgs = Array("-s", RES_DIR_STR, RES_DIR_STR + "/allfields/input", RES_DIR_STR + "/allfields/output", "datamanager")

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
@@ -30,7 +30,7 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
 
   implicit val settings = Settings(
     multidepositDir = new File(testDir, "md"),
-    outputDepositDir = new File(testDir, "dd")
+    stagingDir = new File(testDir, "sd")
   )
 
   val datasetID = "ds1"
@@ -547,7 +547,7 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
 
 
   "execute" should "write the metadata to a file at the correct place" in {
-    val file = outputDatasetMetadataFile(datasetID)
+    val file = stagingDatasetMetadataFile(datasetID)
 
     file should not (exist)
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
@@ -27,8 +27,8 @@ import scala.xml.Utility
 class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with BeforeAndAfterAll {
 
   implicit val settings = Settings(
-    multidepositDir = new File(testDir, "dd"),
-    outputDepositDir = new File(testDir, "dd")
+    multidepositDir = new File(testDir, "md"),
+    stagingDir = new File(testDir, "sd")
   )
   val datasetID = "ruimtereis01"
   val dataset = mutable.HashMap(
@@ -37,13 +37,13 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with Bef
   )
   before {
     new File(getClass.getResource("/spacetravel").toURI)
-      .copyDir(settings.outputDepositDir)
+      .copyDir(settings.multidepositDir)
     new File(getClass.getResource("/mimetypes").toURI)
       .copyDir(new File(testDir, "mimetypes"))
   }
 
   after {
-    settings.outputDepositDir.deleteDirectory()
+    settings.stagingDir.deleteDirectory()
   }
 
   override def afterAll: Unit = testDir.getParentFile.deleteDirectory()
@@ -65,12 +65,12 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter with Bef
 
   "execute" should "write the file metadata to an xml file" in {
     val action = new AddFileMetadataToDeposit(1, (datasetID, dataset))
-    val metadataDir = outputDepositBagMetadataDir(datasetID)
+    val metadataDir = stagingBagMetadataDir(datasetID)
 
     action.execute() shouldBe a[Success[_]]
 
     metadataDir should exist
-    outputFileMetadataFile(datasetID) should exist
+    stagingFileMetadataFile(datasetID) should exist
   }
 
   "datasetToFileXml" should "produce the xml for all the files" in {

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -31,7 +31,7 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with Befor
   val ldapMock: Ldap = mock[Ldap]
   implicit val settings = Settings(
     multidepositDir = new File(testDir, "md"),
-    outputDepositDir = new File(testDir, "dd"),
+    stagingDir = new File(testDir, "sd"),
     datamanager = "dm",
     ldap = ldapMock
   )
@@ -69,7 +69,7 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with Befor
   }
 
   before {
-    new File(settings.outputDepositDir, s"md-$datasetID").mkdirs
+    new File(settings.stagingDir, s"md-$datasetID").mkdirs
     // force datamanagerEmailaddress to be retrieved from LDAP for each test
     AddPropertiesToDeposit.invokePrivate(PrivateMethod[Unit]('resetDatamanagerEmailaddress)())
   }
@@ -216,7 +216,7 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with Befor
 
     AddPropertiesToDeposit(1, (datasetID, dataset)).execute shouldBe a[Success[_]]
 
-    new File(outputDepositDir(datasetID), "deposit.properties") should exist
+    new File(stagingDir(datasetID), "deposit.properties") should exist
   }
 
   "writeProperties" should "generate the properties file and write the properties in it" in {
@@ -224,7 +224,7 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with Befor
 
     AddPropertiesToDeposit(1, (datasetID, dataset)).execute shouldBe a[Success[_]]
 
-    val props = outputPropertiesFile(datasetID)
+    val props = stagingPropertiesFile(datasetID)
     val content = props.read()
     content should include ("state.label")
     content should include ("state.description")

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/CopyToSpringfieldInboxSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/CopyToSpringfieldInboxSpec.scala
@@ -39,7 +39,9 @@ class CopyToSpringfieldInboxSpec extends UnitSpec with BeforeAndAfterAll {
 
   "checkPreconditions" should "fail if file does not exist" in {
     inside(CopyToSpringfieldInbox(1, "videos/some_checkPreFail.mpg").checkPreconditions) {
-      case Failure(ActionException(_, message, _)) => message should include ("Cannot find MD file")
+      case Failure(ActionException(_, message, _)) => message should {
+        include ("Cannot find") and include ("videos/some_checkPreFail.mpg")
+      }
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/CreateOutputDepositDirSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/CreateOutputDepositDirSpec.scala
@@ -26,7 +26,7 @@ class CreateOutputDepositDirSpec extends UnitSpec with BeforeAndAfter with Befor
 
   implicit val settings = Settings(
     multidepositDir = new File(testDir, "md"),
-    outputDepositDir = new File(testDir, "dd")
+    stagingDir = new File(testDir, "sd")
   )
   val datasetID = "ds1"
 
@@ -34,14 +34,14 @@ class CreateOutputDepositDirSpec extends UnitSpec with BeforeAndAfter with Befor
 
   before {
     // create depositDir base directory
-    val baseDir = settings.outputDepositDir
+    val baseDir = settings.stagingDir
     baseDir.mkdir
     baseDir should exist
   }
 
   after {
     // clean up stuff after the test is done
-    val baseDir = settings.outputDepositDir
+    val baseDir = settings.stagingDir
     baseDir.deleteDirectory()
     baseDir should not (exist)
   }
@@ -50,21 +50,21 @@ class CreateOutputDepositDirSpec extends UnitSpec with BeforeAndAfter with Befor
 
   "checkPreconditions" should "succeed if the output directories do not yet exist" in {
     // directories do not exist before
-    outputDepositDir(datasetID) should not (exist)
-    outputDepositBagDir(datasetID) should not (exist)
-    outputDepositBagMetadataDir(datasetID) should not (exist)
+    stagingDir(datasetID) should not (exist)
+    stagingBagDir(datasetID) should not (exist)
+    stagingBagMetadataDir(datasetID) should not (exist)
 
     // creation of directories
     CreateOutputDepositDir(1, datasetID).checkPreconditions shouldBe a[Success[_]]
   }
 
   it should "fail if either one of the output directories does already exist" in {
-    outputDepositBagDir(datasetID).mkdirs()
+    stagingBagDir(datasetID).mkdirs()
 
     // some directories do already exist before
-    outputDepositDir(datasetID) should exist
-    outputDepositBagDir(datasetID) should exist
-    outputDepositBagMetadataDir(datasetID) should not (exist)
+    stagingDir(datasetID) should exist
+    stagingBagDir(datasetID) should exist
+    stagingBagMetadataDir(datasetID) should not (exist)
 
     // creation of directories
     inside(CreateOutputDepositDir(1, datasetID).checkPreconditions) {
@@ -86,23 +86,23 @@ class CreateOutputDepositDirSpec extends UnitSpec with BeforeAndAfter with Befor
     CreateOutputDepositDir(1, datasetID).rollback() shouldBe a[Success[_]]
 
     // test that the directories are really not there anymore
-    outputDepositDir(datasetID) should not (exist)
-    outputDepositBagDir(datasetID) should not (exist)
-    outputDepositBagMetadataDir(datasetID) should not (exist)
+    stagingDir(datasetID) should not (exist)
+    stagingBagDir(datasetID) should not (exist)
+    stagingBagMetadataDir(datasetID) should not (exist)
   }
 
   def executeTest(): Unit = {
     // directories do not exist before
-    outputDepositDir(datasetID) should not (exist)
-    outputDepositBagDir(datasetID) should not (exist)
-    outputDepositBagMetadataDir(datasetID) should not (exist)
+    stagingDir(datasetID) should not (exist)
+    stagingBagDir(datasetID) should not (exist)
+    stagingBagMetadataDir(datasetID) should not (exist)
 
     // creation of directories
     CreateOutputDepositDir(1, datasetID).execute shouldBe a[Success[_]]
 
     // test existance after creation
-    outputDepositDir(datasetID) should exist
-    outputDepositBagDir(datasetID) should exist
-    outputDepositBagMetadataDir(datasetID) should exist
+    stagingDir(datasetID) should exist
+    stagingBagDir(datasetID) should exist
+    stagingBagMetadataDir(datasetID) should exist
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/CreateStagingDirSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/CreateStagingDirSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import scala.util.{Failure, Success}
 
-class CreateOutputDepositDirSpec extends UnitSpec with BeforeAndAfter with BeforeAndAfterAll {
+class CreateStagingDirSpec extends UnitSpec with BeforeAndAfter with BeforeAndAfterAll {
 
   implicit val settings = Settings(
     multidepositDir = new File(testDir, "md"),
@@ -55,7 +55,7 @@ class CreateOutputDepositDirSpec extends UnitSpec with BeforeAndAfter with Befor
     stagingBagMetadataDir(datasetID) should not (exist)
 
     // creation of directories
-    CreateOutputDepositDir(1, datasetID).checkPreconditions shouldBe a[Success[_]]
+    CreateStagingDir(1, datasetID).checkPreconditions shouldBe a[Success[_]]
   }
 
   it should "fail if either one of the output directories does already exist" in {
@@ -67,7 +67,7 @@ class CreateOutputDepositDirSpec extends UnitSpec with BeforeAndAfter with Befor
     stagingBagMetadataDir(datasetID) should not (exist)
 
     // creation of directories
-    inside(CreateOutputDepositDir(1, datasetID).checkPreconditions) {
+    inside(CreateStagingDir(1, datasetID).checkPreconditions) {
       case Failure(ActionException(_, message, _)) => message should include (s"The deposit for dataset $datasetID already exists")
     }
   }
@@ -83,7 +83,7 @@ class CreateOutputDepositDirSpec extends UnitSpec with BeforeAndAfter with Befor
     executeTest()
 
     // roll back the creation of the directories
-    CreateOutputDepositDir(1, datasetID).rollback() shouldBe a[Success[_]]
+    CreateStagingDir(1, datasetID).rollback() shouldBe a[Success[_]]
 
     // test that the directories are really not there anymore
     stagingDir(datasetID) should not (exist)
@@ -98,7 +98,7 @@ class CreateOutputDepositDirSpec extends UnitSpec with BeforeAndAfter with Befor
     stagingBagMetadataDir(datasetID) should not (exist)
 
     // creation of directories
-    CreateOutputDepositDir(1, datasetID).execute shouldBe a[Success[_]]
+    CreateStagingDir(1, datasetID).execute shouldBe a[Success[_]]
 
     // test existance after creation
     stagingDir(datasetID) should exist

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/CreateStagingDirSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/CreateStagingDirSpec.scala
@@ -43,16 +43,16 @@ class CreateStagingDirSpec extends UnitSpec with BeforeAndAfter with BeforeAndAf
     // clean up stuff after the test is done
     val baseDir = settings.stagingDir
     baseDir.deleteDirectory()
-    baseDir should not (exist)
+    baseDir shouldNot exist
   }
 
   override def afterAll: Unit = testDir.getParentFile.deleteDirectory()
 
   "checkPreconditions" should "succeed if the output directories do not yet exist" in {
     // directories do not exist before
-    stagingDir(datasetID) should not (exist)
-    stagingBagDir(datasetID) should not (exist)
-    stagingBagMetadataDir(datasetID) should not (exist)
+    stagingDir(datasetID) shouldNot exist
+    stagingBagDir(datasetID) shouldNot exist
+    stagingBagMetadataDir(datasetID) shouldNot exist
 
     // creation of directories
     CreateStagingDir(1, datasetID).checkPreconditions shouldBe a[Success[_]]
@@ -64,7 +64,7 @@ class CreateStagingDirSpec extends UnitSpec with BeforeAndAfter with BeforeAndAf
     // some directories do already exist before
     stagingDir(datasetID) should exist
     stagingBagDir(datasetID) should exist
-    stagingBagMetadataDir(datasetID) should not (exist)
+    stagingBagMetadataDir(datasetID) shouldNot exist
 
     // creation of directories
     inside(CreateStagingDir(1, datasetID).checkPreconditions) {
@@ -86,16 +86,16 @@ class CreateStagingDirSpec extends UnitSpec with BeforeAndAfter with BeforeAndAf
     CreateStagingDir(1, datasetID).rollback() shouldBe a[Success[_]]
 
     // test that the directories are really not there anymore
-    stagingDir(datasetID) should not (exist)
-    stagingBagDir(datasetID) should not (exist)
-    stagingBagMetadataDir(datasetID) should not (exist)
+    stagingDir(datasetID) shouldNot exist
+    stagingBagDir(datasetID) shouldNot exist
+    stagingBagMetadataDir(datasetID) shouldNot exist
   }
 
   def executeTest(): Unit = {
     // directories do not exist before
-    stagingDir(datasetID) should not (exist)
-    stagingBagDir(datasetID) should not (exist)
-    stagingBagMetadataDir(datasetID) should not (exist)
+    stagingDir(datasetID) shouldNot exist
+    stagingBagDir(datasetID) shouldNot exist
+    stagingBagMetadataDir(datasetID) shouldNot exist
 
     // creation of directories
     CreateStagingDir(1, datasetID).execute shouldBe a[Success[_]]

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/MoveDepositToOutputDirSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/MoveDepositToOutputDirSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.multideposit.actions
 
 import java.io.File

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/MoveDepositToOutputDirSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/MoveDepositToOutputDirSpec.scala
@@ -1,0 +1,80 @@
+package nl.knaw.dans.easy.multideposit.actions
+
+import java.io.File
+
+import nl.knaw.dans.easy.multideposit.{ Settings, UnitSpec, _ }
+import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll }
+
+import scala.util.{ Failure, Success }
+
+class MoveDepositToOutputDirSpec extends UnitSpec with BeforeAndAfter with BeforeAndAfterAll {
+
+  implicit val settings = Settings(
+    multidepositDir = new File(testDir, "input"),
+    stagingDir = new File(testDir, "sd"),
+    outputDepositDir = new File(testDir, "dd")
+  )
+
+  override def beforeAll(): Unit = testDir.mkdirs
+
+  before {
+    // create stagingDir content
+    val baseDir = settings.stagingDir
+    baseDir.mkdir()
+    baseDir should exist
+
+    new File(getClass.getResource("/allfields/output/input-ruimtereis01").toURI)
+      .copyDir(stagingDir("ruimtereis01"))
+    new File(getClass.getResource("/allfields/output/input-ruimtereis02").toURI)
+      .copyDir(stagingDir("ruimtereis02"))
+
+    stagingDir("ruimtereis01") should exist
+    stagingDir("ruimtereis02") should exist
+  }
+
+  after {
+    // clean up stuff after the test is done
+    val stagingDir = settings.stagingDir
+    val outputDepositDir = settings.outputDepositDir
+
+    for (dir <- List(stagingDir, outputDepositDir)) {
+      dir.deleteDirectory()
+      dir shouldNot exist
+    }
+  }
+
+  override def afterAll(): Unit = testDir.getParentFile.deleteDirectory()
+
+  "checkPreconditions" should "verify that the deposit does not yet exist in the outputDepositDir" in {
+    MoveDepositToOutputDir(1, "ruimtereis01").checkPreconditions shouldBe a[Success[_]]
+  }
+
+  it should "fail if the deposit already exists in the outputDepositDir" in {
+    val datasetID = "ruimtereis01"
+    stagingDir(datasetID).copyDir(outputDepositDir(datasetID))
+    outputDepositDir(datasetID) should exist
+
+    inside(MoveDepositToOutputDir(1, datasetID).checkPreconditions) {
+      case Failure(ActionException(1, msg, null)) => msg should include (s"The deposit for dataset $datasetID already exists")
+    }
+  }
+
+  "execute" should "move the deposit to the outputDepositDirectory" in {
+    val datasetID = "ruimtereis01"
+    MoveDepositToOutputDir(1, datasetID).execute() shouldBe a[Success[_]]
+
+    stagingDir(datasetID) shouldNot exist
+    outputDepositDir(datasetID) should exist
+
+    stagingDir("ruimtereis02") should exist
+    outputDepositDir("ruimtereis02") shouldNot exist
+  }
+
+  it should "only move the one deposit to the outputDepositDirectory, not other deposits in the staging directory" in {
+    val datasetID = "ruimtereis01"
+    MoveDepositToOutputDir(1, datasetID).execute() shouldBe a[Success[_]]
+
+    stagingDir("ruimtereis02") should exist
+    outputDepositDir("ruimtereis02") shouldNot exist
+  }
+}

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissionsSpec.scala
@@ -39,13 +39,13 @@ class SetDepositPermissionsSpec extends UnitSpec with BeforeAndAfter with Before
 
   implicit val settings = Settings(
     multidepositDir = new File(testDir, "md"),
-    outputDepositDir = new File(testDir, "dd"),
+    stagingDir = new File(testDir, "sd"),
     depositPermissions = DepositPermissions("rwxrwx---", userGroup)
   )
 
   private val datasetID = "ruimtereis01"
 
-  private val base = outputDepositDir(datasetID)
+  private val base = stagingDir(datasetID)
   private val folder1 = new File(base, "folder1")
   private val folder2 = new File(base, "folder2")
   private val file1 = new File(base, "file1.txt")
@@ -104,7 +104,7 @@ class SetDepositPermissionsSpec extends UnitSpec with BeforeAndAfter with Before
   it should "fail if the group name does not exist" in {
     implicit val settings = Settings(
       multidepositDir = new File(testDir, "md"),
-      outputDepositDir = new File(testDir, "dd"),
+      stagingDir = new File(testDir, "sd"),
       depositPermissions = DepositPermissions("rwxrwx---", "non-existing-group-name")
     )
 
@@ -116,7 +116,7 @@ class SetDepositPermissionsSpec extends UnitSpec with BeforeAndAfter with Before
   it should "fail if the access permissions are invalid" in {
     implicit val settings = Settings(
       multidepositDir = new File(testDir, "md"),
-      outputDepositDir = new File(testDir, "dd"),
+      stagingDir = new File(testDir, "sd"),
       depositPermissions = DepositPermissions("abcdefghi", "admin")
     )
 
@@ -128,7 +128,7 @@ class SetDepositPermissionsSpec extends UnitSpec with BeforeAndAfter with Before
   it should "fail if the user is not part of the given group" in {
     implicit val settings = Settings(
       multidepositDir = new File(testDir, "md"),
-      outputDepositDir = new File(testDir, "dd"),
+      stagingDir = new File(testDir, "sd"),
       depositPermissions = DepositPermissions("rwxrwx---", unrelatedGroup)
     )
 


### PR DESCRIPTION
fixes EASY-1178

#### When applied it will
* add functionality in the debug run script to move the generated data from a previous run to a different folder
* introduce an extra option to the command line interface which sets the staging directory; if not set, the default from the properties file is used
* create the deposit in the staging directory rather than the output directory
* move the deposit to the output directory only when all other actions were successful
* not revert the move if something goes wrong there! (see explanation in that action)

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-dtap                      | [PR#82](https://github.com/DANS-KNAW/easy-dtap/pull/82) 
