### PR TITLE
EASY-1231 Fix swapped XY ccordinates for RD

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -220,10 +220,14 @@ object AddDatasetMetadataToDeposit {
   def createSpatialPoints(dataset: Dataset): Seq[Elem] = {
     dataset.rowsWithValuesForAllOf(composedSpatialPointFields).map(mdKeyValues => {
       val srsName = createSrsName(mdKeyValues)
+
+      val x = mdKeyValues.getOrElse("DCX_SPATIAL_X", "")
+      val y = mdKeyValues.getOrElse("DCX_SPATIAL_Y", "")
+
       // coordinate order x, y = longitude (DCX_SPATIAL_X), latitude (DCX_SPATIAL_Y)
-      lazy val xy = s"${mdKeyValues.getOrElse("DCX_SPATIAL_X", "")} ${mdKeyValues.getOrElse("DCX_SPATIAL_Y", "")}"
+      lazy val xy = s"$x $y"
       // coordinate order y, x = latitude (DCX_SPATIAL_Y), longitude (DCX_SPATIAL_X)
-      lazy val yx = s"${mdKeyValues.getOrElse("DCX_SPATIAL_Y", "")} ${mdKeyValues.getOrElse("DCX_SPATIAL_X", "")}"
+      lazy val yx = s"$y $x"
 
       val pos = srsName match {
         case "http://www.opengis.net/def/crs/EPSG/0/28992" => xy

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -221,9 +221,9 @@ object AddDatasetMetadataToDeposit {
     dataset.rowsWithValuesForAllOf(composedSpatialPointFields).map(mdKeyValues => {
       val srsName = createSrsName(mdKeyValues)
       // coordinate order x, y = longitude (DCX_SPATIAL_X), latitude (DCX_SPATIAL_Y)
-      val xy = s"${mdKeyValues.getOrElse("DCX_SPATIAL_X", "")} ${mdKeyValues.getOrElse("DCX_SPATIAL_Y", "")}"
+      lazy val xy = s"${mdKeyValues.getOrElse("DCX_SPATIAL_X", "")} ${mdKeyValues.getOrElse("DCX_SPATIAL_Y", "")}"
       // coordinate order y, x = latitude (DCX_SPATIAL_Y), longitude (DCX_SPATIAL_X)
-      val yx = s"${mdKeyValues.getOrElse("DCX_SPATIAL_Y", "")} ${mdKeyValues.getOrElse("DCX_SPATIAL_X", "")}"
+      lazy val yx = s"${mdKeyValues.getOrElse("DCX_SPATIAL_Y", "")} ${mdKeyValues.getOrElse("DCX_SPATIAL_X", "")}"
 
       val pos = srsName match {
         case "http://www.opengis.net/def/crs/EPSG/0/28992" => xy
@@ -242,10 +242,11 @@ object AddDatasetMetadataToDeposit {
   }
 
   /*
-   Note that X is along North - South and Y is along East - West
+   Note that Y is along North - South and X is along East - West
    The lower corner is with the minimal coordinate values and upper corner with the maximal coordinate values
    If x was increasing from West to East and y was increasing from South to North we would have
    lower corner (x,y) = (West,South) and upper corner (x,y) = (East,North)
+   as shown in the schematic drawing of the box below.
    This is the case for the WGS84 and RD coordinate systems, but not per se for any other system!
 
                          upper(x,y)=(E,N)
@@ -263,12 +264,12 @@ object AddDatasetMetadataToDeposit {
     dataset.rowsWithValuesForAllOf(composedSpatialBoxFields).map(mdKeyValues => {
       val srsName = createSrsName(mdKeyValues)
 
-      val lowerX = mdKeyValues.getOrElse("DCX_SPATIAL_WEST", "")
-      val upperX = mdKeyValues.getOrElse("DCX_SPATIAL_EAST", "")
-      val lowerY = mdKeyValues.getOrElse("DCX_SPATIAL_SOUTH", "")
-      val upperY = mdKeyValues.getOrElse("DCX_SPATIAL_NORTH", "")
-      val xy = (s"$lowerX $lowerY", s"$upperX $upperY")
-      val yx = (s"$lowerY $lowerX", s"$upperY $upperX")
+      lazy val lowerX = mdKeyValues.getOrElse("DCX_SPATIAL_WEST", "")
+      lazy val upperX = mdKeyValues.getOrElse("DCX_SPATIAL_EAST", "")
+      lazy val lowerY = mdKeyValues.getOrElse("DCX_SPATIAL_SOUTH", "")
+      lazy val upperY = mdKeyValues.getOrElse("DCX_SPATIAL_NORTH", "")
+      lazy val xy = (s"$lowerX $lowerY", s"$upperX $upperY")
+      lazy val yx = (s"$lowerY $lowerX", s"$upperY $upperX")
 
       val (lower, upper) = srsName match {
         case "http://www.opengis.net/def/crs/EPSG/0/28992" => xy

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
@@ -578,16 +578,45 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
       .map(dss => dss.map { case (_, ds) => AddDatasetMetadataToDeposit.datasetToXml(ds) })
   }
 
-  "createDcmiMetadata" should "return the expected spatial elements" in {
+  "createDcmiMetadata" should "return the expected spatial Box elements" in {
     val dataset = new Dataset() +=
       "DCT_SPATIAL" -> List("here", "there", "", "") +=
       "DCX_SPATIAL_SCHEME" -> List("degrees", "RD", "", "") +=
-      "DCX_SPATIAL_X" -> List("83575.4", "", "", "") +=
-      "DCX_SPATIAL_Y" -> List("455271.2", "", "", "") +=
-      "DCX_SPATIAL_NORTH" -> List("", "1", "", "") +=
-      "DCX_SPATIAL_SOUTH" -> List("", "2", "", "") +=
-      "DCX_SPATIAL_EAST" -> List("", "3", "", "") +=
-      "DCX_SPATIAL_WEST" -> List("", "4", "", "")
+      "DCX_SPATIAL_NORTH" -> List("4", "40", "", "") +=
+      "DCX_SPATIAL_SOUTH" -> List("3", "30", "", "") +=
+      "DCX_SPATIAL_EAST" -> List("2", "20", "", "") +=
+      "DCX_SPATIAL_WEST" -> List("1", "10", "", "")
+    val expectedXml = <ddm>
+      <ddm:dcmiMetadata>
+        <dcterms:spatial>here</dcterms:spatial>
+        <dcterms:spatial>there</dcterms:spatial>
+        <dcx-gml:spatial>
+          <boundedBy xmlns="http://www.opengis.net/gml">
+            <Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+              <lowerCorner>3 1</lowerCorner>
+              <upperCorner>4 2</upperCorner>
+            </Envelope>
+          </boundedBy>
+        </dcx-gml:spatial>
+        <dcx-gml:spatial>
+          <boundedBy xmlns="http://www.opengis.net/gml">
+            <Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
+              <lowerCorner>10 30</lowerCorner>
+              <upperCorner>20 40</upperCorner>
+            </Envelope>
+          </boundedBy>
+        </dcx-gml:spatial>
+      </ddm:dcmiMetadata>
+    </ddm>
+    verify(<ddm>{AddDatasetMetadataToDeposit.createMetadata(dataset)}</ddm>, expectedXml)
+  }
+
+  "createDcmiMetadata" should "return the expected spatial Point elements" in {
+    val dataset = new Dataset() +=
+      "DCT_SPATIAL" -> List("here", "there", "", "") +=
+      "DCX_SPATIAL_SCHEME" -> List("degrees", "RD", "", "") +=
+      "DCX_SPATIAL_X" -> List("83575.4", "210902", "", "") +=
+      "DCX_SPATIAL_Y" -> List("455271.2", "442193", "", "")
     val expectedXml = <ddm>
       <ddm:dcmiMetadata>
         <dcterms:spatial>here</dcterms:spatial>
@@ -597,13 +626,10 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
             <pos>455271.2 83575.4</pos>
           </Point>
         </dcx-gml:spatial>
-        <dcx-gml:spatial>
-          <boundedBy xmlns="http://www.opengis.net/gml">
-            <Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
-              <lowerCorner>1 3</lowerCorner>
-              <upperCorner>2 4</upperCorner>
-            </Envelope>
-          </boundedBy>
+        <dcx-gml:spatial srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
+          <Point xmlns="http://www.opengis.net/gml">
+            <pos>210902 442193</pos>
+          </Point>
         </dcx-gml:spatial>
       </ddm:dcmiMetadata>
     </ddm>


### PR DESCRIPTION
fixes EASY-1231

#### When applied it will
* fix the swapping

#### Where should the reviewer @DANS-KNAW/easy start?
createSpatialBoxes and createSpatialPoints in
easy-split-multi-deposit/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala

and 
easy-split-multi-deposit/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
Look for 
` "createDcmiMetadata" should "return the expected spatial Box elements" in`
and
`"createDcmiMetadata" should "return the expected spatial Point elements" in `