### PR TITLE
Param action

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,16 +41,19 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.11</artifactId>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.scalacheck</groupId>
             <artifactId>scalacheck_2.11</artifactId>
+            <version>1.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock-scalatest-support_2.11</artifactId>
+            <version>3.3.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/Action.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/Action.scala
@@ -135,10 +135,10 @@ trait Action[-A, +T] extends DebugEnhancedLogging { self =>
    * @return an `Action` that composes these two actions sequentially
    */
   def combine[S](other: Action[T, S]): Action[A, S] = new Action[A, S] {
-    private var pastLeft = false
+    private var pastSelf = false
 
     override def run(a: A): Try[S] = {
-      pastLeft = false
+      pastSelf = false
       super.run(a)
     }
 
@@ -153,13 +153,13 @@ trait Action[-A, +T] extends DebugEnhancedLogging { self =>
     override protected def execute(a: A): Try[S] = {
       for {
         t <- self.innerExecute(a)
-        _ = pastLeft = true
+        _ = pastSelf = true
         s <- other.innerExecute(t)
       } yield s
     }
 
     override protected def rollback(): Try[Unit] = {
-      (if (pastLeft) List(other, self) else List(self))
+      (if (pastSelf) List(other, self) else List(self))
         .map(_.innerRollback())
         .collectResults
         .map(_ => ())

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
@@ -18,8 +18,8 @@ package nl.knaw.dans.easy.multideposit
 import nl.knaw.dans.easy.multideposit.actions._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
-import scala.collection.mutable.ListBuffer
-import scala.util.Try
+import scala.language.postfixOps
+import scala.util.{ Failure, Try }
 
 object Main extends DebugEnhancedLogging {
 
@@ -40,39 +40,46 @@ object Main extends DebugEnhancedLogging {
 
   def run(implicit settings: Settings): Try[Unit] = {
     MultiDepositParser.parse(multiDepositInstructionsFile)
-      .flatMap(getActions(_).reduce(_ andThen _).run())
+      .flatMap(getActions(_).map(_.run(())).getOrElse(Failure(new Exception)))
   }
 
-  def getActions(datasets: Datasets)(implicit settings: Settings): ListBuffer[Action[Unit]] = {
+  def getActions(datasets: Datasets)(implicit settings: Settings): Option[Action[Unit, Unit]] = {
     logger.info("Compiling list of actions to perform ...")
 
     val retrieveDatamanagerAction = RetrieveDatamanagerAction()
-    val datasetActions = datasets.flatMap {
+    val datasetActions = datasets.map {
       case entry@(datasetID, dataset) =>
         val row = dataset.getRowNumber
         logger.debug(s"Getting actions for dataset $datasetID ...")
 
-        Seq(CreateStagingDir(row, datasetID),
-          AddBagToDeposit(row, entry),
-          AddDatasetMetadataToDeposit(row, entry),
-          AddFileMetadataToDeposit(row, entry),
-          retrieveDatamanagerAction.applyRight(AddPropertiesToDeposit(row, entry)),
-          SetDepositPermissions(row, datasetID)) ++ getFileActions(dataset)
-    }
+        val acts = CreateStagingDir(row, datasetID)
+          .combine(AddBagToDeposit(row, entry))
+          .combine(AddDatasetMetadataToDeposit(row, entry))
+          .combine(AddFileMetadataToDeposit(row, entry))
+          .combine(retrieveDatamanagerAction)
+          .combine(AddPropertiesToDeposit(row, entry))
+          .combine(SetDepositPermissions(row, datasetID))
+
+        getFileActions(dataset).fold(acts)(acts combine)
+    }.reduceOption(_ combine _)
     val createSpringfieldAction = CreateSpringfieldActions(-1, datasets)
     val moveActions = datasets.map {
-      case (datasetID, dataset) => MoveDepositToOutputDir(dataset.getRowNumber, datasetID)
-    }
+      case (datasetID, dataset) => MoveDepositToOutputDir(dataset.getRowNumber, datasetID): Action[Unit, Unit]
+    }.reduceOption(_ combine _)
 
-    datasetActions += createSpringfieldAction ++= moveActions
+    for {
+      dsAct <- datasetActions
+      mvAct <- moveActions
+    } yield dsAct combine createSpringfieldAction combine mvAct
   }
 
-  def getFileActions(dataset: Dataset)(implicit settings: Settings): Seq[Action[Unit]] = {
+  def getFileActions(dataset: Dataset)(implicit settings: Settings): Option[Action[Unit, Unit]] = {
     extractFileParameters(dataset)
       .collect {
         case FileParameters(Some(row), Some(fileMd), _, _, _, Some(isThisAudioVideo)) if isThisAudioVideo matches "(?i)yes" =>
-          CopyToSpringfieldInbox(row, fileMd)
+          CopyToSpringfieldInbox(row, fileMd): Action[Unit, Unit]
       }
+      .reduceOption(_ combine _)
   }
 
   def extractFileParameters(dataset: Dataset): Seq[FileParameters] = {

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/Main.scala
@@ -43,32 +43,6 @@ object Main extends DebugEnhancedLogging {
       .flatMap(getActions(_).reduce(_ andThen _).run())
   }
 
-//  def getAllActions(datasets: Datasets)(implicit settings: Settings): Action[Unit] = {
-//    logger.info("Compiling list of actions to perform ...")
-//
-//    val retrieveDatamanagerAction = RetrieveDatamanagerAction()
-//    val datasetActions = datasets.map {
-//      case entry@(datasetID, dataset) =>
-//        val row = dataset.getRowNumber
-//        logger.debug(s"Getting actions for dataset $datasetID ...")
-//
-//        CreateStagingDir(row, datasetID)
-//          .andThen(AddBagToDeposit(row, entry))
-//          .andThen(AddDatasetMetadataToDeposit(row, entry))
-//          .andThen(AddFileMetadataToDeposit(row, entry))
-//          .andThen(retrieveDatamanagerAction)
-//          .applyRight(AddPropertiesToDeposit(row, entry))
-//          .andThen(SetDepositPermissions(row, datasetID))
-//          .andThen(getFileActions(dataset).reduce(_ andThen _))
-//    }.reduce(_ andThen _)
-//    val createSpringfieldAction = CreateSpringfieldActions(-1, datasets)
-//    val moveActions = datasets.map {
-//      case (datasetID, dataset) => MoveDepositToOutputDir(dataset.getRowNumber, datasetID): Action[Unit]
-//    }.reduce(_ andThen _)
-//
-//    datasetActions.andThen(createSpringfieldAction).andThen(moveActions)
-//  }
-
   def getActions(datasets: Datasets)(implicit settings: Settings): ListBuffer[Action[Unit]] = {
     logger.info("Compiling list of actions to perform ...")
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddBagToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddBagToDeposit.scala
@@ -33,7 +33,7 @@ import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Try }
 
-case class AddBagToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[Unit] {
+case class AddBagToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends UnitAction[Unit] {
 
   val (datasetID, dataset) = entry
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddBagToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddBagToDeposit.scala
@@ -33,7 +33,7 @@ import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Try }
 
-case class AddBagToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action {
+case class AddBagToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[Unit] {
 
   val (datasetID, dataset) = entry
 
@@ -91,7 +91,7 @@ object AddBagToDeposit {
   }
 }
 
-class BagInfoCompleter(bagFactory: BagFactory, dataset: Dataset) extends Completer {
+private class BagInfoCompleter(bagFactory: BagFactory, dataset: Dataset) extends Completer {
 
   def complete(bag: Bag): Bag = {
     val newBag = bagFactory.createBag(bag)

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 import scala.xml.Elem
 
-case class AddDatasetMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action {
+case class AddDatasetMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[Unit] {
 
   val (datasetID, dataset) = entry
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 import scala.xml.Elem
 
-case class AddDatasetMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[Unit] {
+case class AddDatasetMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends UnitAction[Unit] {
 
   val (datasetID, dataset) = entry
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy.multideposit.actions
 import java.io.File
 
 import nl.knaw.dans.easy.multideposit.actions.AddFileMetadataToDeposit._
-import nl.knaw.dans.easy.multideposit.{ Action, Settings, _ }
+import nl.knaw.dans.easy.multideposit.{ UnitAction, Settings, _ }
 import nl.knaw.dans.lib.error.TraversableTryExtensions
 import org.apache.tika.Tika
 
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 import scala.xml.Elem
 
-case class AddFileMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[Unit] {
+case class AddFileMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends UnitAction[Unit] {
 
   val (datasetID, dataset) = entry
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDeposit.scala
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 import scala.xml.Elem
 
-case class AddFileMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action {
+case class AddFileMetadataToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[Unit] {
 
   val (datasetID, dataset) = entry
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDeposit.scala
@@ -26,7 +26,7 @@ import scala.language.postfixOps
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
-case class AddPropertiesToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[DatamanagerEmailaddress => Unit] {
+case class AddPropertiesToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[DatamanagerEmailaddress, Unit] {
 
   val (datasetID, dataset) = entry
 
@@ -34,8 +34,8 @@ case class AddPropertiesToDeposit(row: Int, entry: (DatasetID, Dataset))(implici
 
   override def checkPreconditions: Try[Unit] = validateDepositor(row, datasetID, dataset)
 
-  override def execute(): Try[DatamanagerEmailaddress => Unit] = Try {
-    (datamanagerEmailaddress: DatamanagerEmailaddress) => writeProperties(row, datasetID, dataset, datamanagerEmailaddress).get
+  override def execute(datamanagerEmailaddress: DatamanagerEmailaddress): Try[Unit] = {
+    writeProperties(row, datasetID, dataset, datamanagerEmailaddress)
   }
 }
 object AddPropertiesToDeposit {

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDeposit.scala
@@ -34,7 +34,7 @@ case class AddPropertiesToDeposit(row: Int, entry: (DatasetID, Dataset))(implici
 
   override def checkPreconditions: Try[Unit] = validateDepositor(row, datasetID, dataset)
 
-  override def execute(): Try[String => Unit] = Try {
+  override def execute(): Try[DatamanagerEmailaddress => Unit] = Try {
     (datamanagerEmailaddress: DatamanagerEmailaddress) => writeProperties(row, datasetID, dataset, datamanagerEmailaddress).get
   }
 }
@@ -67,7 +67,7 @@ object AddPropertiesToDeposit {
       .getOrElse(Failure(ActionException(row, """The column "DEPOSITOR_ID" is not present""")))
   }
 
-  def writeProperties(row: Int, datasetID: DatasetID, dataset: Dataset, emailaddress: String)(implicit settings: Settings): Try[Unit] = {
+  def writeProperties(row: Int, datasetID: DatasetID, dataset: Dataset, emailaddress: DatamanagerEmailaddress)(implicit settings: Settings): Try[Unit] = {
     val props = new Properties {
       // Make sure we get sorted output, which is better readable than random
       override def keys(): ju.Enumeration[AnyRef] = Collections.enumeration(new ju.TreeSet[Object](super.keySet()))
@@ -80,7 +80,7 @@ object AddPropertiesToDeposit {
       }
   }
 
-  def addProperties(properties: Properties, dataset: Dataset, datamanager: String, emailaddress: String): Try[Unit] = {
+  def addProperties(properties: Properties, dataset: Dataset, datamanager: String, emailaddress: DatamanagerEmailaddress): Try[Unit] = {
     for {
       depositorUserID <- dataset.get("DEPOSITOR_ID")
         .flatMap(_.headOption)

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDeposit.scala
@@ -27,7 +27,7 @@ import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 import nl.knaw.dans.lib.error.TraversableTryExtensions
 
-case class AddPropertiesToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action {
+case class AddPropertiesToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[Unit] {
 
   val (datasetID, dataset) = entry
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDeposit.scala
@@ -25,9 +25,8 @@ import resource._
 import scala.language.postfixOps
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
-import nl.knaw.dans.lib.error.TraversableTryExtensions
 
-case class AddPropertiesToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[String => Unit] {
+case class AddPropertiesToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[DatamanagerEmailaddress => Unit] {
 
   val (datasetID, dataset) = entry
 
@@ -36,7 +35,7 @@ case class AddPropertiesToDeposit(row: Int, entry: (DatasetID, Dataset))(implici
   override def checkPreconditions: Try[Unit] = validateDepositor(row, datasetID, dataset)
 
   override def execute(): Try[String => Unit] = Try {
-    (datamanagerEmailaddress: String) => writeProperties(row, datasetID, dataset, datamanagerEmailaddress).get
+    (datamanagerEmailaddress: DatamanagerEmailaddress) => writeProperties(row, datasetID, dataset, datamanagerEmailaddress).get
   }
 }
 object AddPropertiesToDeposit {

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDeposit.scala
@@ -27,65 +27,19 @@ import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 import nl.knaw.dans.lib.error.TraversableTryExtensions
 
-case class AddPropertiesToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[Unit] {
+case class AddPropertiesToDeposit(row: Int, entry: (DatasetID, Dataset))(implicit settings: Settings) extends Action[String => Unit] {
 
   val (datasetID, dataset) = entry
 
   // TODO administratieve metadata, to be decided
 
-  override def checkPreconditions: Try[Unit] = {
-    List(validateDepositor(row, datasetID, dataset), getDatamanagerMailadres)
-      .collectResults
-      .map(_ => ())
-  }
+  override def checkPreconditions: Try[Unit] = validateDepositor(row, datasetID, dataset)
 
-  override def execute(): Try[Unit] = getDatamanagerMailadres.flatMap(writeProperties(row, datasetID, dataset, _))
+  override def execute(): Try[String => Unit] = Try {
+    (datamanagerEmailaddress: String) => writeProperties(row, datasetID, dataset, datamanagerEmailaddress).get
+  }
 }
 object AddPropertiesToDeposit {
-  // The email needs to be acquired (from LDAP) only once during the program execution
-  private var datamanagerEmailaddress: Try[String] = _
-
-  // Only used for testing
-  private def resetDatamanagerEmailaddress() = {
-    datamanagerEmailaddress = null
-  }
-
-  /**
-   * Tries to retrieve the email address of the datamanager
-   * Also used for validation: checks if the datamanager is an active archivist with an email address
-   */
-  def getDatamanagerMailadres(implicit settings: Settings): Try[String] = {
-    val row = -1
-    // Note that the datamanager 'precondition' is checked when datamanagerEmailaddress is evaluated the first time
-    if(datamanagerEmailaddress == null) {
-      val id = settings.datamanager
-      datamanagerEmailaddress = settings.ldap.query(id)(a => a)
-        .flatMap(attrsSeq => {
-          if (attrsSeq.isEmpty) Failure(ActionException(row, s"""The datamanager "$id" is unknown"""))
-          else if (attrsSeq.size > 1) Failure(ActionException(row, s"""There appear to be multiple users with id "$id""""))
-          else Success(attrsSeq.head)
-        })
-        .flatMap(attrs => {
-          Option(attrs.get("dansState"))
-            .filter(_.get.toString == "ACTIVE")
-            .map(_ => Success(attrs))
-            .getOrElse(Failure(ActionException(row, s"""The datamanager "$id" is not an active user""")))
-        })
-        .flatMap(attrs => {
-          Option(attrs.get("easyRoles"))
-            .filter(_.contains("ARCHIVIST"))
-            .map(_ => Success(attrs))
-            .getOrElse(Failure(ActionException(row, s"""The datamanager "$id" is not an archivist""")))
-        })
-        .flatMap(attrs => {
-          Option(attrs.get("mail"))
-            .filter(_.get().toString.nonEmpty)
-            .map(att => Success(att.get().toString))
-            .getOrElse(Failure(ActionException(row, s"""The datamanager "$id" does not have an email address""")))
-        })
-    }
-    datamanagerEmailaddress
-  }
 
   /**
    * Checks whether there is only one unique DEPOSITOR_ID set in the `Dataset` (there can be multiple values but the must all be equal!).

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CopyToSpringfieldInbox.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CopyToSpringfieldInbox.scala
@@ -20,7 +20,7 @@ import nl.knaw.dans.easy.multideposit.{ Action, ActionException, Settings, _ }
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-case class CopyToSpringfieldInbox(row: Int, fileMd: String)(implicit settings: Settings) extends Action {
+case class CopyToSpringfieldInbox(row: Int, fileMd: String)(implicit settings: Settings) extends Action[Unit] {
 
   private val mdDir = multiDepositDir(fileMd)
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CopyToSpringfieldInbox.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CopyToSpringfieldInbox.scala
@@ -20,7 +20,7 @@ import nl.knaw.dans.easy.multideposit.{ Action, ActionException, Settings, _ }
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-case class CopyToSpringfieldInbox(row: Int, fileMd: String)(implicit settings: Settings) extends Action[Unit] {
+case class CopyToSpringfieldInbox(row: Int, fileMd: String)(implicit settings: Settings) extends UnitAction[Unit] {
 
   private val mdDir = multiDepositDir(fileMd)
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateSpringfieldActions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateSpringfieldActions.scala
@@ -31,7 +31,7 @@ TODO For this Action all datasets need to be in memory at the same time. However
      With this, we can eventually make the whole application reactive by also parsing the csv lazily
      and reactive.
  */
-case class CreateSpringfieldActions(row: Int, datasets: Datasets)(implicit settings: Settings) extends Action {
+case class CreateSpringfieldActions(row: Int, datasets: Datasets)(implicit settings: Settings) extends Action[Unit] {
 
   override def execute(): Try[Unit] = CreateSpringfieldActions.writeSpringfieldXml(row, datasets)
 }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateSpringfieldActions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateSpringfieldActions.scala
@@ -31,7 +31,7 @@ TODO For this Action all datasets need to be in memory at the same time. However
      With this, we can eventually make the whole application reactive by also parsing the csv lazily
      and reactive.
  */
-case class CreateSpringfieldActions(row: Int, datasets: Datasets)(implicit settings: Settings) extends Action[Unit] {
+case class CreateSpringfieldActions(row: Int, datasets: Datasets)(implicit settings: Settings) extends UnitAction[Unit] {
 
   override def execute(): Try[Unit] = CreateSpringfieldActions.writeSpringfieldXml(row, datasets)
 }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateStagingDir.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateStagingDir.scala
@@ -20,7 +20,7 @@ import nl.knaw.dans.easy.multideposit._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-case class CreateStagingDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action {
+case class CreateStagingDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action[Unit] {
 
   private val stagingDirectory = stagingDir(datasetID)
   private val bagDir = stagingBagDir(datasetID)

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateStagingDir.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/CreateStagingDir.scala
@@ -20,7 +20,7 @@ import nl.knaw.dans.easy.multideposit._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-case class CreateStagingDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action[Unit] {
+case class CreateStagingDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends UnitAction[Unit] {
 
   private val stagingDirectory = stagingDir(datasetID)
   private val bagDir = stagingBagDir(datasetID)

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/MoveDepositToOutputDir.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/MoveDepositToOutputDir.scala
@@ -22,7 +22,7 @@ import org.apache.commons.io.FileExistsException
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-case class MoveDepositToOutputDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action[Unit] {
+case class MoveDepositToOutputDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends UnitAction[Unit] {
 
   private val outputDir = outputDepositDir(datasetID)
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/MoveDepositToOutputDir.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/MoveDepositToOutputDir.scala
@@ -22,7 +22,7 @@ import org.apache.commons.io.FileExistsException
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-case class MoveDepositToOutputDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action {
+case class MoveDepositToOutputDir(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action[Unit] {
 
   private val outputDir = outputDepositDir(datasetID)
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerAction.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerAction.scala
@@ -27,13 +27,13 @@ case class RetrieveDatamanagerAction(implicit settings: Settings) extends Action
     datamanagerEmailaddress.map(_ => ())
   }
 
-  override def execute(): Try[String] = datamanagerEmailaddress
+  override def execute(): Try[DatamanagerEmailaddress] = datamanagerEmailaddress
 
   /**
    * Tries to retrieve the email address of the datamanager
    * Also used for validation: checks if the datamanager is an active archivist with an email address
    */
-  private def getDatamanagerMailadres(implicit settings: Settings): Try[String] = {
+  private def getDatamanagerMailadres(implicit settings: Settings): Try[DatamanagerEmailaddress] = {
     val row = -1
     // Note that the datamanager 'precondition' is checked when datamanagerEmailaddress is evaluated the first time
     val datamanagerId = settings.datamanager

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerAction.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerAction.scala
@@ -1,0 +1,52 @@
+package nl.knaw.dans.easy.multideposit.actions
+
+import nl.knaw.dans.easy.multideposit.{ Action, ActionException, Dataset, DatasetID, Settings }
+
+import scala.util.{ Failure, Success, Try }
+
+case class RetrieveDatamanagerAction(implicit settings: Settings) extends Action[String] {
+
+  private lazy val datamanagerEmailaddress = RetrieveDatamanagerAction.getDatamanagerMailadres
+
+  override def checkPreconditions: Try[Unit] = {
+    datamanagerEmailaddress.map(_ => ())
+  }
+
+  override def execute(): Try[String] = datamanagerEmailaddress
+}
+
+object RetrieveDatamanagerAction {
+  /**
+   * Tries to retrieve the email address of the datamanager
+   * Also used for validation: checks if the datamanager is an active archivist with an email address
+   */
+  def getDatamanagerMailadres(implicit settings: Settings): Try[String] = {
+    val row = -1
+    // Note that the datamanager 'precondition' is checked when datamanagerEmailaddress is evaluated the first time
+    val datamanagerId = settings.datamanager
+    settings.ldap.query(datamanagerId)(a => a)
+      .flatMap(attrsSeq => {
+        if (attrsSeq.isEmpty) Failure(ActionException(row, s"""The datamanager "$datamanagerId" is unknown"""))
+        else if (attrsSeq.size > 1) Failure(ActionException(row, s"""There appear to be multiple users with id "$datamanagerId""""))
+        else Success(attrsSeq.head)
+      })
+      .flatMap(attrs => {
+        Option(attrs.get("dansState"))
+          .filter(_.get.toString == "ACTIVE")
+          .map(_ => Success(attrs))
+          .getOrElse(Failure(ActionException(row, s"""The datamanager "$datamanagerId" is not an active user""")))
+      })
+      .flatMap(attrs => {
+        Option(attrs.get("easyRoles"))
+          .filter(_.contains("ARCHIVIST"))
+          .map(_ => Success(attrs))
+          .getOrElse(Failure(ActionException(row, s"""The datamanager "$datamanagerId" is not an archivist""")))
+      })
+      .flatMap(attrs => {
+        Option(attrs.get("mail"))
+          .filter(_.get().toString.nonEmpty)
+          .map(att => Success(att.get().toString))
+          .getOrElse(Failure(ActionException(row, s"""The datamanager "$datamanagerId" does not have an email address""")))
+      })
+  }
+}

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerAction.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerAction.scala
@@ -1,26 +1,24 @@
 package nl.knaw.dans.easy.multideposit.actions
 
-import nl.knaw.dans.easy.multideposit.{ Action, ActionException, Dataset, DatasetID, Settings }
+import nl.knaw.dans.easy.multideposit.{ Action, ActionException, DatamanagerEmailaddress, Settings }
 
 import scala.util.{ Failure, Success, Try }
 
-case class RetrieveDatamanagerAction(implicit settings: Settings) extends Action[String] {
+case class RetrieveDatamanagerAction(implicit settings: Settings) extends Action[DatamanagerEmailaddress] {
 
-  private lazy val datamanagerEmailaddress = RetrieveDatamanagerAction.getDatamanagerMailadres
+  private lazy val datamanagerEmailaddress = getDatamanagerMailadres
 
   override def checkPreconditions: Try[Unit] = {
     datamanagerEmailaddress.map(_ => ())
   }
 
   override def execute(): Try[String] = datamanagerEmailaddress
-}
 
-object RetrieveDatamanagerAction {
   /**
    * Tries to retrieve the email address of the datamanager
    * Also used for validation: checks if the datamanager is an active archivist with an email address
    */
-  def getDatamanagerMailadres(implicit settings: Settings): Try[String] = {
+  private def getDatamanagerMailadres(implicit settings: Settings): Try[String] = {
     val row = -1
     // Note that the datamanager 'precondition' is checked when datamanagerEmailaddress is evaluated the first time
     val datamanagerId = settings.datamanager

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerAction.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerAction.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.multideposit.actions
 
 import nl.knaw.dans.easy.multideposit.{ Action, ActionException, DatamanagerEmailaddress, Settings }

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerAction.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerAction.scala
@@ -15,11 +15,11 @@
  */
 package nl.knaw.dans.easy.multideposit.actions
 
-import nl.knaw.dans.easy.multideposit.{ Action, ActionException, DatamanagerEmailaddress, Settings }
+import nl.knaw.dans.easy.multideposit.{ UnitAction, ActionException, DatamanagerEmailaddress, Settings }
 
 import scala.util.{ Failure, Success, Try }
 
-case class RetrieveDatamanagerAction(implicit settings: Settings) extends Action[DatamanagerEmailaddress] {
+case class RetrieveDatamanagerAction(implicit settings: Settings) extends UnitAction[DatamanagerEmailaddress] {
 
   private lazy val datamanagerEmailaddress = getDatamanagerMailadres
 

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
@@ -26,7 +26,7 @@ import scala.language.postfixOps
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-case class SetDepositPermissions(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action {
+case class SetDepositPermissions(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action[Unit] {
 
   def execute(): Try[Unit] = {
     setFilePermissions().recoverWith {

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/SetDepositPermissions.scala
@@ -19,14 +19,14 @@ import java.io.{ File, IOException }
 import java.nio.file._
 import java.nio.file.attribute._
 
-import nl.knaw.dans.easy.multideposit.{ Action, DatasetID, _ }
+import nl.knaw.dans.easy.multideposit.{ UnitAction, DatasetID, _ }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.language.postfixOps
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-case class SetDepositPermissions(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends Action[Unit] {
+case class SetDepositPermissions(row: Int, datasetID: DatasetID)(implicit settings: Settings) extends UnitAction[Unit] {
 
   def execute(): Try[Unit] = {
     setFilePermissions().recoverWith {

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/package.scala
@@ -39,6 +39,7 @@ package object multideposit {
   def Datasets: Datasets = ListBuffer.empty
 
   type DatasetRow = mutable.HashMap[MultiDepositKey, String]
+  type DatamanagerEmailaddress = String
 
   case class FileParameters(row: Option[Int], sip: Option[String], dataset: Option[String],
                             storageService: Option[String], storagePath: Option[String],

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ActionLawSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ActionLawSpec.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ActionLawSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ActionLawSpec.scala
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.easy.multideposit
 
-import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{ Inside, Matchers, PropSpec }
@@ -24,67 +23,9 @@ import scala.util.Try
 
 class ActionLawSpec extends PropSpec with PropertyChecks with Matchers with Inside with CustomMatchers {
 
-  implicit def arbAction[T](implicit t: Arbitrary[T]): Arbitrary[Action[T]] = {
-    Arbitrary(for {
-      pre <- arbitrary[Try[Unit]]
-      exe <- arbitrary[Try[T]]
-      undo <- arbitrary[Try[Unit]]
-    } yield Action(() => pre, () => exe, () => undo))
-  }
-
-  // fmap id == id
-  property("action - functor identity") {
-    forAll { a: Action[Int] =>
-      a.map(identity) should equalAction(a)
-    }
-  }
-
-  // fmap (g . h) == (fmap g) . (fmap h)
-  property("action - functor composition") {
-    forAll { (a: Action[Int], f: Int => String, g: String => Long) =>
-      a.map(g compose f) should equalAction(a.map(f).map(g))
-    }
-  }
-
-  // pure id <*> v == v
-  property("action - applicative identity") {
-    forAll { a: Action[Int] =>
-      Action.from[Int => Int](identity).applyLeft(a) should equalAction(a)
-    }
-  }
-
-  // pure f <*> pure x == pure (f x)
-  property("action - applicative homomorphism") {
-    forAll { (i: Int, f: Int => String) =>
-      Action.from(f).applyLeft(Action.from(i)) should equalAction(Action.from(f(i)))
-    }
-  }
-
-  // u <*> pure y == pure ($ y) <*> u
-  property("action - applicative interchange") {
-    forAll { (i: Int, actionF: Action[Int => String]) =>
-      actionF.applyLeft(Action.from(i)) should equalAction(Action.from[(Int => String) => String](_(i)).applyLeft(actionF))
-    }
-  }
-
-  // fmap v f == pure ($ f) <*> v
-  property("action - applicative map") {
-    forAll { (action: Action[Int], f: Int => String) =>
-      action.map(f) should equalAction(Action.from(f).applyLeft(action))
-    }
-  }
-
-  // u <*> (v <*> w) == ((pure (.) <*> u) <*> v) <*> w
-  property("action - applicative composition") {
-    forAll { (actionIntToString: Action[Int => String], actionLongToInt: Action[Long => Int], appLong: Action[Long]) =>
-      val left = actionIntToString.applyLeft(actionLongToInt.applyLeft(appLong))
-
-      val pure = Action.from[(Int => String) => (Long => Int) => Long => String](_.compose)
-      val f = pure.applyLeft(actionIntToString)
-      val g = f.applyLeft(actionLongToInt)
-      val right = g.applyLeft(appLong)
-
-      left should equalAction(right)
+  property("action - category composition") {
+    forAll { (i: Int, f: Int => Try[String], g: String => Try[Long]) =>
+      Action(action = f).combine(Action(action = g)).run(i) shouldBe Action[Int, Long](action = f(_).flatMap(g)).run(i)
     }
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ActionLawSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ActionLawSpec.scala
@@ -49,7 +49,7 @@ class ActionLawSpec extends PropSpec with PropertyChecks with Matchers with Insi
   // pure id <*> v == v
   property("action - applicative identity") {
     forAll { a: Action[Int] =>
-      a.applyRight(Action.from[Int => Int](identity)) should equalAction(a)
+      Action.from[Int => Int](identity).applyLeft(a) should equalAction(a)
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/ActionLawSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/ActionLawSpec.scala
@@ -18,33 +18,73 @@ package nl.knaw.dans.easy.multideposit
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ Matchers, PropSpec }
+import org.scalatest.{ Inside, Matchers, PropSpec }
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.Try
 
-class ActionLawSpec extends PropSpec with PropertyChecks with Matchers {
+class ActionLawSpec extends PropSpec with PropertyChecks with Matchers with Inside with CustomMatchers {
 
-  implicit def arbTry[T](implicit a: Arbitrary[T]): Arbitrary[Try[T]] = {
-    Arbitrary(arbitrary[Option[T]].map(_.map(Success(_)).getOrElse(Failure(new Exception("failure")))))
-  }
-
-  implicit def arbAction: Arbitrary[Action] = {
+  implicit def arbAction[T](implicit t: Arbitrary[T]): Arbitrary[Action[T]] = {
     Arbitrary(for {
       pre <- arbitrary[Try[Unit]]
-      exe <- arbitrary[Try[Unit]]
+      exe <- arbitrary[Try[T]]
       undo <- arbitrary[Try[Unit]]
     } yield Action(() => pre, () => exe, () => undo))
   }
 
-  property("action - semigroup associativity") {
-    forAll { (a1: Action, a2: Action, a3: Action) =>
-      a1.compose(a2).compose(a3) shouldBe a1.compose(a2.compose(a3))
+  // fmap id == id
+  property("action - functor identity") {
+    forAll { a: Action[Int] =>
+      a.map(identity) should equalAction(a)
     }
   }
 
-  property("action - semigroup combined") {
-    forAll { (a1: Action, a2: Action, a3: Action, a4: Action) =>
-      a1.compose(a2).compose(a3.compose(a4)) shouldBe a1.compose(a2).compose(a3).compose(a4)
+  // fmap (g . h) == (fmap g) . (fmap h)
+  property("action - functor composition") {
+    forAll { (a: Action[Int], f: Int => String, g: String => Long) =>
+      a.map(g compose f) should equalAction(a.map(f).map(g))
+    }
+  }
+
+  // pure id <*> v == v
+  property("action - applicative identity") {
+    forAll { a: Action[Int] =>
+      a.applyRight(Action.from[Int => Int](identity)) should equalAction(a)
+    }
+  }
+
+  // pure f <*> pure x == pure (f x)
+  property("action - applicative homomorphism") {
+    forAll { (i: Int, f: Int => String) =>
+      Action.from(f).applyLeft(Action.from(i)) should equalAction(Action.from(f(i)))
+    }
+  }
+
+  // u <*> pure y == pure ($ y) <*> u
+  property("action - applicative interchange") {
+    forAll { (i: Int, actionF: Action[Int => String]) =>
+      actionF.applyLeft(Action.from(i)) should equalAction(Action.from[(Int => String) => String](_(i)).applyLeft(actionF))
+    }
+  }
+
+  // fmap v f == pure ($ f) <*> v
+  property("action - applicative map") {
+    forAll { (action: Action[Int], f: Int => String) =>
+      action.map(f) should equalAction(Action.from(f).applyLeft(action))
+    }
+  }
+
+  // u <*> (v <*> w) == ((pure (.) <*> u) <*> v) <*> w
+  property("action - applicative composition") {
+    forAll { (actionIntToString: Action[Int => String], actionLongToInt: Action[Long => Int], appLong: Action[Long]) =>
+      val left = actionIntToString.applyLeft(actionLongToInt.applyLeft(appLong))
+
+      val pure = Action.from[(Int => String) => (Long => Int) => Long => String](_.compose)
+      val f = pure.applyLeft(actionIntToString)
+      val g = f.applyLeft(actionLongToInt)
+      val right = g.applyLeft(appLong)
+
+      left should equalAction(right)
     }
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/CustomMatchers.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/CustomMatchers.scala
@@ -17,9 +17,10 @@ package nl.knaw.dans.easy.multideposit
 
 import java.io.File
 
-import scala.io.Source
+import org.scalatest.matchers.{ MatchResult, Matcher }
 
-import org.scalatest.matchers.{MatchResult, Matcher}
+import scala.io.Source
+import scala.util.{ Failure, Success }
 
 /** Does not dump the full file but just the searched content if it is not found.
   *
@@ -36,4 +37,19 @@ trait CustomMatchers {
     }
   }
   def containTrimmed(content: String) = new ContentMatcher(content)
+
+  class ActionMatcher[T](right: Action[T]) extends Matcher[Action[T]] {
+    def apply(left: Action[T]): MatchResult = {
+      MatchResult(
+        (left.run(), right.run()) match {
+          case (Success(x), Success(y)) => x == y
+          case (Failure(e1), Failure(e2)) => e1.getMessage == e2.getMessage && e1.getClass == e2.getClass
+          case _ => false
+        },
+        s"$left did not equal $right",
+        s"$left equals $right"
+      )
+    }
+  }
+  def equalAction[T](right: Action[T]) = new ActionMatcher(right)
 }

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/CustomMatchers.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/CustomMatchers.scala
@@ -20,7 +20,6 @@ import java.io.File
 import org.scalatest.matchers.{ MatchResult, Matcher }
 
 import scala.io.Source
-import scala.util.{ Failure, Success }
 
 /** Does not dump the full file but just the searched content if it is not found.
   *
@@ -37,19 +36,4 @@ trait CustomMatchers {
     }
   }
   def containTrimmed(content: String) = new ContentMatcher(content)
-
-  class ActionMatcher[T](right: Action[T]) extends Matcher[Action[T]] {
-    def apply(left: Action[T]): MatchResult = {
-      MatchResult(
-        (left.run(), right.run()) match {
-          case (Success(x), Success(y)) => x == y
-          case (Failure(e1), Failure(e2)) => e1.getMessage == e2.getMessage && e1.getClass == e2.getClass
-          case _ => false
-        },
-        s"$left did not equal $right",
-        s"$left equals $right"
-      )
-    }
-  }
-  def equalAction[T](right: Action[T]) = new ActionMatcher(right)
 }

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/MainSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/MainSpec.scala
@@ -17,8 +17,7 @@ package nl.knaw.dans.easy.multideposit
 
 import java.io.File
 
-import nl.knaw.dans.easy.multideposit.Main._
-import nl.knaw.dans.easy.multideposit.actions.{ CreateSpringfieldActions, _ }
+import nl.knaw.dans.easy.multideposit.Main.extractFileParameters
 
 import scala.language.reflectiveCalls
 
@@ -29,61 +28,6 @@ class MainSpec extends UnitSpec {
     stagingDir = new File(testDir, "dd"),
     springfieldInbox = new File(testDir, "sfi")
   )
-
-  val retrieveDatamanagerAction = RetrieveDatamanagerAction()
-  val generalActions = Seq(
-    CreateSpringfieldActions(-1, testDatasets),
-    MoveDepositToOutputDir(2, testDatasets.head._1),
-    MoveDepositToOutputDir(2, testDatasets.tail.head._1))
-
-  val dataset1Actions = new {
-    val entry @ (datasetID, dataset) = testDatasets.head
-    val datasetActions = Seq(
-      CreateStagingDir(2, datasetID),
-      AddBagToDeposit(2, entry),
-      AddDatasetMetadataToDeposit(2, entry),
-      AddFileMetadataToDeposit(2, entry),
-      Action.CombinedAction(retrieveDatamanagerAction, AddPropertiesToDeposit(2, entry))((s, f) => f(s)),
-      SetDepositPermissions(2, datasetID))
-    val fileActions = Seq(CopyToSpringfieldInbox(2, "videos/centaur.mpg"))
-  }
-
-  val dataset2Actions = new {
-    val entry @ (datasetID, dataset) = testDatasets.tail.head
-    val datasetActions = Seq(
-      CreateStagingDir(2, datasetID),
-      AddBagToDeposit(2, entry),
-      AddDatasetMetadataToDeposit(2, entry),
-      AddFileMetadataToDeposit(2, entry),
-      Action.CombinedAction(retrieveDatamanagerAction, AddPropertiesToDeposit(2, entry))((s, f) => f(s)),
-      SetDepositPermissions(2, datasetID))
-    val fileActions = Seq(CopyToSpringfieldInbox(4, "videos/centaur.mpg"))
-  }
-
-  "getActions" should "return all actions to be performed given the collection of datasets" in {
-    getActions(testDatasets) should {
-      have size 17 and
-        contain allElementsOf generalActions and
-        contain allElementsOf dataset1Actions.datasetActions and
-        contain allElementsOf dataset1Actions.fileActions and
-        contain allElementsOf dataset2Actions.datasetActions and
-        contain allElementsOf dataset2Actions.fileActions
-    }
-  }
-
-  "getFileActions" should "return an action for each FileParameters object that is an A/V file" in {
-    import dataset1Actions._
-    getFileActions(dataset) should {
-      have size 1 and contain theSameElementsInOrderAs fileActions
-    }
-  }
-
-  it should "do the same for testDataset2" in {
-    import dataset2Actions._
-    getFileActions(dataset) should {
-      have size 1 and contain theSameElementsInOrderAs fileActions
-    }
-  }
 
   "extractFileParameters" should "only yield the FileParameters where not all fields are empty" in {
     extractFileParameters(testDataset1) should {

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/MainSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/MainSpec.scala
@@ -30,6 +30,7 @@ class MainSpec extends UnitSpec {
     springfieldInbox = new File(testDir, "sfi")
   )
 
+  val retrieveDatamanagerAction = RetrieveDatamanagerAction()
   val generalActions = Seq(
     CreateSpringfieldActions(-1, testDatasets),
     MoveDepositToOutputDir(2, testDatasets.head._1),
@@ -42,7 +43,7 @@ class MainSpec extends UnitSpec {
       AddBagToDeposit(2, entry),
       AddDatasetMetadataToDeposit(2, entry),
       AddFileMetadataToDeposit(2, entry),
-      AddPropertiesToDeposit(2, entry),
+      Action.CombinedAction(retrieveDatamanagerAction, AddPropertiesToDeposit(2, entry))((s, f) => f(s)),
       SetDepositPermissions(2, datasetID))
     val fileActions = Seq(CopyToSpringfieldInbox(2, "videos/centaur.mpg"))
   }
@@ -54,7 +55,7 @@ class MainSpec extends UnitSpec {
       AddBagToDeposit(2, entry),
       AddDatasetMetadataToDeposit(2, entry),
       AddFileMetadataToDeposit(2, entry),
-      AddPropertiesToDeposit(2, entry),
+      Action.CombinedAction(retrieveDatamanagerAction, AddPropertiesToDeposit(2, entry))((s, f) => f(s)),
       SetDepositPermissions(2, datasetID))
     val fileActions = Seq(CopyToSpringfieldInbox(4, "videos/centaur.mpg"))
   }
@@ -62,31 +63,11 @@ class MainSpec extends UnitSpec {
   "getActions" should "return all actions to be performed given the collection of datasets" in {
     getActions(testDatasets) should {
       have size 17 and
-      contain theSameElementsInOrderAs(
-        dataset1Actions.datasetActions ++ dataset1Actions.fileActions ++
-        dataset2Actions.datasetActions ++ dataset2Actions.fileActions ++
-        generalActions
-      )
-    }
-  }
-
-  "getGeneralActions" should "return a collection of actions that are supposed to run only once for all datasets" in {
-    getGeneralActions(testDatasets) should {
-      have size 3 and contain theSameElementsInOrderAs generalActions
-    }
-  }
-
-  "getDatasetActions" should "return a collection of actions for the given dataset" in {
-    import dataset1Actions._
-    getDatasetActions(entry) should {
-      have size 7 and contain theSameElementsInOrderAs (datasetActions ++ fileActions)
-    }
-  }
-
-  it should "do the same for testDataset2" in {
-    import dataset2Actions._
-    getDatasetActions(entry) should {
-      have size 7 and contain theSameElementsInOrderAs (datasetActions ++ fileActions)
+        contain allElementsOf generalActions and
+        contain allElementsOf dataset1Actions.datasetActions and
+        contain allElementsOf dataset1Actions.fileActions and
+        contain allElementsOf dataset2Actions.datasetActions and
+        contain allElementsOf dataset2Actions.fileActions
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -40,45 +40,18 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with Befor
     "DEPOSITOR_ID" -> List("dp1", "", "", "")
   )
 
-  private val correctDatamanagerAttrs = createDatamanagerAttributes()
-
-  /**
-   * Default creates correct BasicAttributes
-   */
-  def createDatamanagerAttributes(state: String = "ACTIVE",
-                                  roles: Seq[String] = Seq("USER","ARCHIVIST"),
-                                  mail: String = "dm@test.org"): BasicAttributes = {
-
-    val a = new BasicAttributes()
-    a.put("dansState", state)
-    a.put({
-      val r = new BasicAttribute("easyRoles")
-      roles.foreach(r.add)
-      r
-    })
-    a.put("mail", mail)
-    a
-  }
-
-  def mockLdapForDatamanager(attrs: Attributes): Unit = {
-    (ldapMock.query(_: String)(_: Attributes => Attributes)) expects ("dm", *) returning Success(Seq(attrs))
-  }
-
   def mockLdapForDepositor(b: Boolean): Unit = {
     (ldapMock.query(_: String)(_: Attributes => Boolean)) expects ("dp1", *) returning Success(Seq(b))
   }
 
   before {
     new File(settings.stagingDir, s"md-$datasetID").mkdirs
-    // force datamanagerEmailaddress to be retrieved from LDAP for each test
-    AddPropertiesToDeposit.invokePrivate(PrivateMethod[Unit]('resetDatamanagerEmailaddress)())
   }
 
   override def afterAll: Unit = testDir.getParentFile.deleteDirectory()
 
-  "checkPreconditions" should "succeed if the depositorID is in the dataset and has one value and the datamanager email can be retrieved" in {
+  "checkPreconditions" should "succeed if the depositorID is in the dataset" in {
     mockLdapForDepositor(true)
-    mockLdapForDatamanager(correctDatamanagerAttrs)
 
     AddPropertiesToDeposit(1, (datasetID, dataset)).checkPreconditions shouldBe a[Success[_]]
   }
@@ -88,76 +61,17 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with Befor
       "DEPOSITOR_ID" -> List("dp1", "dp1", "dp1", "dp1")
     )
     mockLdapForDepositor(true)
-    mockLdapForDatamanager(correctDatamanagerAttrs)
 
     AddPropertiesToDeposit(1, (datasetID, dataset)).checkPreconditions shouldBe a[Success[_]]
-  }
-
-  it should "fail if ldap does not return anything for the datamanager" in {
-    mockLdapForDepositor(true)
-    (ldapMock.query(_: String)(_: Attributes => Attributes)) expects ("dm", *) returning Success(Seq.empty)
-
-    inside(AddPropertiesToDeposit(1, (datasetID, dataset)).checkPreconditions) {
-      case Failure(CompositeException(es)) =>
-        es should have size 1
-        val ActionException(_, message, _) :: Nil = es
-        message should include ("""The datamanager "dm" is unknown""")
-    }
-  }
-
-  it should "fail when the datamanager is not an active user" in {
-    val nonActiveDatamanagerAttrs = createDatamanagerAttributes(state = "BLOCKED")
-
-    mockLdapForDepositor(true)
-    mockLdapForDatamanager(nonActiveDatamanagerAttrs)
-
-    inside(AddPropertiesToDeposit(1, (datasetID, dataset)).checkPreconditions) {
-      case Failure(CompositeException(es)) =>
-        es should have size 1
-        val ActionException(_, message, _) :: Nil = es
-        message should include ("not an active user")
-    }
-  }
-
-  it should "fail when the datamanager is not an achivist" in {
-    val nonArchivistDatamanagerAttrs = createDatamanagerAttributes(roles = Seq("USER"))
-
-    mockLdapForDepositor(true)
-    mockLdapForDatamanager(nonArchivistDatamanagerAttrs)
-
-    inside(AddPropertiesToDeposit(1, (datasetID, dataset)).checkPreconditions) {
-      case Failure(CompositeException(es)) =>
-        es should have size 1
-        val ActionException(_, message, _) :: Nil = es
-        message should include ("is not an archivist")
-    }
-  }
-
-  it should "fail when the datamanager has no email" in {
-    val nonEmailDatamanagerAttrs = createDatamanagerAttributes(mail = "")
-
-    mockLdapForDepositor(true)
-    mockLdapForDatamanager(nonEmailDatamanagerAttrs)
-
-    inside(AddPropertiesToDeposit(1, (datasetID, dataset)).checkPreconditions) {
-      case Failure(CompositeException(es)) =>
-        es should have size 1
-        val ActionException(_, message, _) :: Nil = es
-        message should include ("does not have an email address")
-    }
   }
 
   it should "fail when the depositorID column is not in the dataset" in {
     val dataset = mutable.HashMap(
       "TEST_COLUMN" -> List("abc", "def")
     )
-    mockLdapForDatamanager(correctDatamanagerAttrs)
 
     inside(AddPropertiesToDeposit(1, (datasetID, dataset)).checkPreconditions) {
-      case Failure(CompositeException(es)) =>
-        es should have size 1
-        val ActionException(_, message, _) :: Nil = es
-        message should include ("is not present")
+      case Failure(ActionException(_, message, _)) => message should include ("is not present")
     }
   }
 
@@ -165,66 +79,44 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with Befor
     val dataset = mutable.HashMap(
       "DEPOSITOR_ID" -> List("dp1", "dp1", "dp2", "dp1")
     )
-    mockLdapForDatamanager(correctDatamanagerAttrs)
 
     inside(AddPropertiesToDeposit(1, (datasetID, dataset)).checkPreconditions) {
-      case Failure(CompositeException(es)) =>
-        es should have size 1
-        val ActionException(_, message, _) :: Nil = es
-        message should include ("multiple distinct")
+      case Failure(ActionException(_, message, _)) => message should include ("multiple distinct")
     }
   }
 
   it should "fail if ldap identifies the depositorID as not active" in {
     mockLdapForDepositor(false)
-    mockLdapForDatamanager(correctDatamanagerAttrs)
 
     inside(AddPropertiesToDeposit(1, (datasetID, dataset)).checkPreconditions) {
-      case Failure(CompositeException(es)) =>
-        es should have size 1
-        val ActionException(_, message, _) :: Nil = es
-        message should include ("""depositor "dp1" is not an active user""")
+      case Failure(ActionException(_, message, _)) => message should include ("""depositor "dp1" is not an active user""")
     }
   }
 
   it should "fail if ldap does not return anything for the depositor" in {
     (ldapMock.query(_: String)(_: Attributes => Boolean)) expects ("dp1", *) returning Success(Seq.empty)
-    mockLdapForDatamanager(correctDatamanagerAttrs)
 
     inside(AddPropertiesToDeposit(1, (datasetID, dataset)).checkPreconditions) {
-      case Failure(CompositeException(es)) =>
-        es should have size 1
-        val ActionException(_, message, _) :: Nil = es
-        message should include ("""DepositorID "dp1" is unknown""")
+      case Failure(ActionException(_, message, _)) => message should include ("""DepositorID "dp1" is unknown""")
     }
   }
 
   it should "fail if ldap returns multiple values" in {
     (ldapMock.query(_: String)(_: Attributes => Boolean)) expects ("dp1", *) returning Success(Seq(true, true))
-    mockLdapForDatamanager(correctDatamanagerAttrs)
 
     inside(AddPropertiesToDeposit(1, (datasetID, dataset)).checkPreconditions) {
-      case Failure(CompositeException(es)) =>
-        es should have size 1
-        val ActionException(_, message, _) :: Nil = es
-        message should include ("""multiple users with id "dp1"""")
+      case Failure(ActionException(_, message, _)) => message should include ("""multiple users with id "dp1"""")
     }
   }
 
-  "execute" should "generate the properties file" in {
-    mockLdapForDatamanager(correctDatamanagerAttrs)
-
-    AddPropertiesToDeposit(1, (datasetID, dataset)).execute shouldBe a[Success[_]]
-
-    new File(stagingDir(datasetID), "deposit.properties") should exist
-  }
-
-  "writeProperties" should "generate the properties file and write the properties in it" in {
-    mockLdapForDatamanager(correctDatamanagerAttrs)
-
-    AddPropertiesToDeposit(1, (datasetID, dataset)).execute shouldBe a[Success[_]]
+  "execute" should "generate the properties file and write the properties in it" in {
+    inside(AddPropertiesToDeposit(1, (datasetID, dataset)).execute()) {
+      case Success(f) => f("dm@test.org")
+    }
 
     val props = stagingPropertiesFile(datasetID)
+    props should exist
+
     val content = props.read()
     content should include ("state.label")
     content should include ("state.description")

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -110,9 +110,7 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with Befor
   }
 
   "execute" should "generate the properties file and write the properties in it" in {
-    inside(AddPropertiesToDeposit(1, (datasetID, dataset)).execute()) {
-      case Success(f) => f("dm@test.org")
-    }
+    AddPropertiesToDeposit(1, (datasetID, dataset)).execute().map(f => f("dm@test.org")) shouldBe a[Success[_]]
 
     val props = stagingPropertiesFile(datasetID)
     props should exist

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, PrivateMethodTester }
 import scala.collection.mutable
 import scala.util.{ Failure, Success }
 
-class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with BeforeAndAfterAll with MockFactory with PrivateMethodTester {
+class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with BeforeAndAfterAll with MockFactory {
 
   val ldapMock: Ldap = mock[Ldap]
   implicit val settings = Settings(

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -16,12 +16,11 @@
 package nl.knaw.dans.easy.multideposit.actions
 
 import java.io.File
-import javax.naming.directory.{ Attributes, BasicAttribute, BasicAttributes }
+import javax.naming.directory.Attributes
 
 import nl.knaw.dans.easy.multideposit.{ ActionException, Settings, UnitSpec, _ }
-import nl.knaw.dans.lib.error.CompositeException
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, PrivateMethodTester }
+import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll }
 
 import scala.collection.mutable
 import scala.util.{ Failure, Success }
@@ -110,7 +109,7 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfter with Befor
   }
 
   "execute" should "generate the properties file and write the properties in it" in {
-    AddPropertiesToDeposit(1, (datasetID, dataset)).execute().map(f => f("dm@test.org")) shouldBe a[Success[_]]
+    AddPropertiesToDeposit(1, (datasetID, dataset)).execute("dm@test.org") shouldBe a[Success[_]]
 
     val props = stagingPropertiesFile(datasetID)
     props should exist

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerActionSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerActionSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.multideposit.actions
 
 import java.io.File

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerActionSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerActionSpec.scala
@@ -1,0 +1,96 @@
+package nl.knaw.dans.easy.multideposit.actions
+
+import java.io.File
+import javax.naming.directory.{ Attributes, BasicAttribute, BasicAttributes }
+
+import nl.knaw.dans.easy.multideposit.{ Ldap, Settings, UnitSpec, _ }
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterAll
+
+import scala.util.{ Failure, Success }
+
+class RetrieveDatamanagerActionSpec extends UnitSpec with BeforeAndAfterAll with MockFactory {
+
+  val ldapMock: Ldap = mock[Ldap]
+  implicit val settings = Settings(
+    multidepositDir = new File(testDir, "md"),
+    stagingDir = new File(testDir, "sd"),
+    datamanager = "dm",
+    ldap = ldapMock
+  )
+
+  private val correctDatamanagerAttrs = createDatamanagerAttributes()
+
+  /**
+   * Default creates correct BasicAttributes
+   */
+  def createDatamanagerAttributes(state: String = "ACTIVE",
+                                  roles: Seq[String] = Seq("USER","ARCHIVIST"),
+                                  mail: String = "dm@test.org"): BasicAttributes = {
+
+    val a = new BasicAttributes()
+    a.put("dansState", state)
+    a.put({
+      val r = new BasicAttribute("easyRoles")
+      roles.foreach(r.add)
+      r
+    })
+    a.put("mail", mail)
+    a
+  }
+
+  def mockLdapForDatamanager(attrs: Attributes): Unit = {
+    (ldapMock.query(_: String)(_: Attributes => Attributes)) expects ("dm", *) returning Success(Seq(attrs))
+  }
+
+  override def afterAll: Unit = testDir.getParentFile.deleteDirectory()
+
+  "checkPreconditions" should "succeed if the datamanager email can be retrieved" in {
+    mockLdapForDatamanager(correctDatamanagerAttrs)
+
+    RetrieveDatamanagerAction().checkPreconditions shouldBe a[Success[_]]
+  }
+
+  it should "fail if ldap does not return anything for the datamanager" in {
+    (ldapMock.query(_: String)(_: Attributes => Attributes)) expects ("dm", *) returning Success(Seq.empty)
+
+    inside(RetrieveDatamanagerAction().checkPreconditions) {
+      case Failure(ActionException(_, message, _)) => message should include ("""The datamanager "dm" is unknown""")
+    }
+  }
+
+  it should "fail when the datamanager is not an active user" in {
+    val nonActiveDatamanagerAttrs = createDatamanagerAttributes(state = "BLOCKED")
+    mockLdapForDatamanager(nonActiveDatamanagerAttrs)
+
+    inside(RetrieveDatamanagerAction().checkPreconditions) {
+      case Failure(ActionException(_, message, _)) => message should include ("not an active user")
+    }
+  }
+
+  it should "fail when the datamanager is not an achivist" in {
+    val nonArchivistDatamanagerAttrs = createDatamanagerAttributes(roles = Seq("USER"))
+    mockLdapForDatamanager(nonArchivistDatamanagerAttrs)
+
+    inside(RetrieveDatamanagerAction().checkPreconditions) {
+      case Failure(ActionException(_, message, _)) => message should include ("is not an archivist")
+    }
+  }
+
+  it should "fail when the datamanager has no email" in {
+    val nonEmailDatamanagerAttrs = createDatamanagerAttributes(mail = "")
+    mockLdapForDatamanager(nonEmailDatamanagerAttrs)
+
+    inside(RetrieveDatamanagerAction().checkPreconditions) {
+      case Failure(ActionException(_, message, _)) => message should include ("does not have an email address")
+    }
+  }
+
+  "execute" should "generate the properties file" in {
+    mockLdapForDatamanager(correctDatamanagerAttrs)
+
+    inside(RetrieveDatamanagerAction().execute()) {
+      case Success(mail) => mail shouldBe "dm@test.org"
+    }
+  }
+}

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerActionSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/RetrieveDatamanagerActionSpec.scala
@@ -55,7 +55,7 @@ class RetrieveDatamanagerActionSpec extends UnitSpec with BeforeAndAfterAll with
   }
 
   def mockLdapForDatamanager(attrs: Attributes): Unit = {
-    (ldapMock.query(_: String)(_: Attributes => Attributes)) expects ("dm", *) returning Success(Seq(attrs))
+    (ldapMock.query(_: String)(_: Attributes => Attributes)) expects ("dm", *) once() returning Success(Seq(attrs))
   }
 
   override def afterAll: Unit = testDir.getParentFile.deleteDirectory()
@@ -107,5 +107,16 @@ class RetrieveDatamanagerActionSpec extends UnitSpec with BeforeAndAfterAll with
     inside(RetrieveDatamanagerAction().execute()) {
       case Success(mail) => mail shouldBe "dm@test.org"
     }
+  }
+
+  it should "only compute the datamanager email once, eventhough some methods were called twice"  in {
+    // this call makes sure ldap is only called once
+    mockLdapForDatamanager(correctDatamanagerAttrs)
+    val action = RetrieveDatamanagerAction()
+
+    action.checkPreconditions shouldBe a[Success[_]]
+    action.execute() shouldBe a[Success[_]]
+    action.checkPreconditions shouldBe a[Success[_]]
+    action.execute() shouldBe a[Success[_]]
   }
 }


### PR DESCRIPTION
**prepares EASY-1167 and EASY-1168**

#### When applied it will
* parameterize `Action` such that `execute` returns `Try[T]` rather than `Try[Unit]`. This allows actions to return computed results, such that they can be reused in multiple other actions. As this is required for EASY-1167 and EASY-1168, I thought I would do this first.
* An example of this reusing is the datamanager email that is retrieved from LDAP (**IO is expensive!**) and therefore only needs to be done once per multi-deposit run. Instead of our former complicated way of doing this by making the email a singleton that defaults to `null`, we refactor this into its own `Action` that returns the email `String`. Then the properties action that requires this email, can get it via function application that is already provided in the `Action`'s API.

#### Where should the reviewer @DANS-KNAW/easy start?
Start in `Action.scala`, then continue to `RetrieveDatamanagerAction.scala` and `AddPropertiesToDeposit.scala` and finally look at the integration in `Main.scala`.