### PR TITLE
extra check for SF_ACCESSIBILITY

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDeposit.scala
@@ -66,6 +66,7 @@ object AddDatasetMetadataToDeposit {
       checkColumnHasOnlyOneValue(row, dataset, "DDM_CREATED"),
       checkColumnHasOnlyOneValue(row, dataset, "DDM_ACCESSRIGHTS"),
       checkColumnHasAtMostOneValue(row, dataset, "DDM_AVAILABLE"),
+      checkColumnHasAtMostOneValue(row, dataset, "SF_ACCESSIBILITY"),
       checkColumnsHaveAtMostOneRowWithValues(row, dataset, "SF_DOMAIN", "SF_USER", "SF_COLLECTION")
     )
   }

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
@@ -982,8 +982,7 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
     )
     inside(AddDatasetMetadataToDeposit(1, (datasetID, dataset)).checkPreconditions) {
       case Failure(CompositeException(es)) =>
-        val ActionException(_, message, _) :: Nil = es.toList
-        message shouldBe "More than one value is defined for SF_ACCESSIBILITY"
+        es.toList.map(_.getMessage) should contain ("More than one value is defined for SF_ACCESSIBILITY")
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddDatasetMetadataToDepositSpec.scala
@@ -965,6 +965,28 @@ class AddDatasetMetadataToDepositSpec extends UnitSpec with BeforeAndAfterAll {
     }
   }
 
+  it should "fail with multiple access rights" in {
+    val dataset = basicDataset ++= List(
+      "SF_ACCESSIBILITY" -> List("ANONYMOUS", "RESTRICTED_REQUEST")
+    )
+    inside(AddDatasetMetadataToDeposit(1, (datasetID, dataset)).checkPreconditions) {
+      case Failure(CompositeException(es)) =>
+        val ActionException(_, message, _) :: Nil = es.toList
+        message shouldBe "More than one value is defined for SF_ACCESSIBILITY"
+    }
+  }
+
+  it should "fail with multiple access rights where not all are valid" in {
+    val dataset = basicDataset ++= List(
+      "SF_ACCESSIBILITY" -> List("ANONYMOUS", "incorrect_access")
+    )
+    inside(AddDatasetMetadataToDeposit(1, (datasetID, dataset)).checkPreconditions) {
+      case Failure(CompositeException(es)) =>
+        val ActionException(_, message, _) :: Nil = es.toList
+        message shouldBe "More than one value is defined for SF_ACCESSIBILITY"
+    }
+  }
+
   "execute" should "write the metadata to a file at the correct place" in {
     val file = stagingDatasetMetadataFile(datasetID)
 


### PR DESCRIPTION
~~fixes EASY-~~

#### When applied it will
* add an extra check to make sure that `SF_ACCESSIBILITY` has at most one value per dataset

@DANS-KNAW/easy for review