### PR TITLE
fix failing tests on Eko's machine

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddBagToDeposit.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/actions/AddBagToDeposit.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.multideposit.actions
 
 import java.io.{ File, FileInputStream }
+import java.util.Locale
 
 import gov.loc.repository.bagit.BagFactory.Version
 import gov.loc.repository.bagit.Manifest.Algorithm
@@ -34,6 +35,10 @@ import scala.util.control.NonFatal
 import scala.util.{ Failure, Try }
 
 case class AddBagToDeposit(dataset: Dataset)(implicit settings: Settings) extends UnitAction[Unit] {
+
+  override def checkPreconditions: Try[Unit] = Try {
+    Locale.setDefault(Locale.US)
+  }
 
   override def execute(): Try[Unit] = {
     createBag(dataset.datasetId, dataset).recoverWith {

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/parser/Dataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/parser/Dataset.scala
@@ -53,7 +53,7 @@ case class Metadata(alternatives: List[String] = List.empty,
 
 case class AudioVideo(springfield: Option[Springfield] = Option.empty,
                       accessibility: Option[FileAccessRights.Value] = Option.empty,
-                      avFiles: List[AVFile] = List.empty)
+                      avFiles: Set[AVFile] = Set.empty)
 
 sealed abstract class Creator
 case class CreatorOrganization(organization: String) extends Creator

--- a/src/main/scala/nl/knaw/dans/easy/multideposit/parser/MultiDepositParser.scala
+++ b/src/main/scala/nl/knaw/dans/easy/multideposit/parser/MultiDepositParser.scala
@@ -248,7 +248,7 @@ class MultiDepositParser(implicit settings: Settings) extends DebugEnhancedLoggi
 
   def extractAudioVideo(rows: DatasetRows, rowNum: Int): Try[AudioVideo] = {
     Try {
-      ((springf: Option[Springfield], acc: Option[FileAccessRights.Value], avFiles: List[AVFile]) => {
+      ((springf: Option[Springfield], acc: Option[FileAccessRights.Value], avFiles: Set[AVFile]) => {
         (springf, acc, avFiles) match {
           case (None, _, fs) if fs.nonEmpty => Failure(ParseException(rowNum, "The column " +
             "'AV_FILE' contains values, but the columns [SF_COLLECTION, SF_USER] do not"))
@@ -273,7 +273,7 @@ class MultiDepositParser(implicit settings: Settings) extends DebugEnhancedLoggi
               val subtitles = instrPerFile.collect { case (_, _, Some(instr)) => instr }
 
               fileTitle.map(AVFile(file, _, subtitles))
-          }.toList.collectResults))
+          }.collectResults.map(_.toSet)))
       .flatten
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/UnitSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/UnitSpec.scala
@@ -64,7 +64,7 @@ abstract class UnitSpec extends FlatSpec with Matchers with OptionValues with In
       ),
       audioVideo = AudioVideo(
         springfield = Option(Springfield("dans", "janvanmansum", "Jans-test-files")),
-        avFiles = List(AVFile(
+        avFiles = Set(AVFile(
           file = new File("ruimtereis01/reisverslag/centaur.mpg"),
           title = Option("flyby of centaur"),
           subtitles = List(Subtitles(new File("ruimtereis01/reisverslag/centaur.srt"), Option("en")))

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/actions/AddFileMetadataToDepositSpec.scala
@@ -122,7 +122,7 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter {
       datasetId = datasetID,
       audioVideo = testDataset1.audioVideo.copy(
         accessibility = Option(FileAccessRights.NONE),
-        avFiles = List(AVFile(new File("ruimtereis01/reisverslag/centaur.mpg")))
+        avFiles = Set(AVFile(new File("ruimtereis01/reisverslag/centaur.mpg")))
       )
     )
     val action = AddFileMetadataToDeposit(dataset)
@@ -140,7 +140,7 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfter {
       audioVideo = AudioVideo(
         springfield = Option(Springfield("dans", "janvanmansum", "Jans-test-files")),
         accessibility = Option(FileAccessRights.RESTRICTED_GROUP),
-        avFiles = List(
+        avFiles = Set(
           AVFile(
             file = new File(settings.multidepositDir, "ruimtereis01/reisverslag/centaur.mpg").getAbsoluteFile,
             title = Option("video about the centaur meteorite"),

--- a/src/test/scala/nl/knaw/dans/easy/multideposit/parser/MultiDepositParserSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/multideposit/parser/MultiDepositParserSpec.scala
@@ -725,7 +725,7 @@ class MultiDepositParserSpec extends UnitSpec with MockFactory {
   private lazy val audioVideo = AudioVideo(
     springfield = Option(Springfield("dans", "janvanmansum", "jans-test-files")),
     accessibility = Option(FileAccessRights.NONE),
-    avFiles = List(
+    avFiles = Set(
       AVFile(
         file = new File(settings.multidepositDir, "ruimtereis01/reisverslag/centaur.mpg").getAbsoluteFile,
         title = Option("video about the centaur meteorite"),


### PR DESCRIPTION
~~fixes EASY-~~

#### When applied it will
* fix tests that failed on @ekoi's machine. The issue is that I forgot that the `groupBy` that is used in the `AV_FILE` selection doesn't preserve order in the resulting `Map`. Therefore the order that is stated in the tests worked for me, but did apparently not work for @ekoi. With this fix I no longer compare the lists themselves, but rather the _elements in the lists_.
* hardcode the `Locale` in order to make sure formatting of the `Bag-Size` in `bag-info.txt` is done correctly.

@DANS-KNAW/easy for review
@ekoi thanks for finding this bug!