### PR TITLE
EASY-1397: fix ordering bug in tests

### DIFF
--- a/src/test/scala/nl.knaw.dans.easy.multideposit/CustomMatchers.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/CustomMatchers.scala
@@ -60,9 +60,27 @@ trait CustomMatchers {
         {
           left.size == right.size && left.map(l => right.exists(l ==)).forall(true ==)
         },
-        s"$left did not contain the same elements as $right",
+        // TODO showing the diffs should be done better, but I don't know yet how to use the IntelliJ supported solution to get a nice diff
+        // need to look deeper into that.
+        s"$left did not contain the same elements as $right: ${ missingLeft(left, right) }; ${ missingRight(left, right) }",
         s"$left did contain the same elements as $right"
       )
+    }
+
+    private def missingLeft(left: Iterable[Node], right: Iterable[Node]) = {
+      val diff = right.toList diff left.toList
+      diff match {
+        case Nil => ""
+        case _ => s"Missing in left: ${ diff.mkString("[", ", ", "]") }"
+      }
+    }
+
+    private def missingRight(left: Iterable[Node], right: Iterable[Node]) = {
+      val diff = left.toList diff right.toList
+      diff match {
+        case Nil => ""
+        case _ => s"Missing in right: ${ diff.mkString("[", ", ", "]") }"
+      }
     }
   }
   def containAllNodes(right: Iterable[Node]) = new ContainAllTrimmed(right)

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/CustomMatchers.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/CustomMatchers.scala
@@ -20,6 +20,7 @@ import java.nio.file.Path
 import org.scalatest.matchers.{ MatchResult, Matcher }
 
 import scala.io.Source
+import scala.language.postfixOps
 import scala.xml._
 
 /** Does not dump the full file but just the searched content if it is not found.
@@ -52,4 +53,17 @@ trait CustomMatchers {
     }
   }
   def equalTrimmed(right: Iterable[Node]) = new EqualTrimmedMatcher(right)
+
+  class ContainAllTrimmed(right: Iterable[Node]) extends Matcher[Iterable[Node]] {
+    override def apply(left: Iterable[Node]): MatchResult = {
+      MatchResult(
+        {
+          left.size == right.size && left.map(l => right.exists(l ==)).forall(true ==)
+        },
+        s"$left did not contain the same elements as $right",
+        s"$left did contain the same elements as $right"
+      )
+    }
+  }
+  def containAllNodes(right: Iterable[Node]) = new ContainAllTrimmed(right)
 }

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddFileMetadataToDepositSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddFileMetadataToDepositSpec.scala
@@ -133,8 +133,7 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfterEach with
     stagingFileMetadataFile(deposit.depositId).toFile should exist
   }
 
-  // TODO: Fix this test, see EASY-1397
-  ignore should "produce the xml for all the files" in {
+  it should "produce the xml for all the files" in {
     val deposit = testDeposit1.copy(
       depositId = depositId,
       files = Map(
@@ -159,11 +158,10 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfterEach with
     val actual = XML.loadFile(stagingFileMetadataFile(depositId).toFile)
     val expected = XML.loadFile(Paths.get(getClass.getResource("/allfields/output/input-ruimtereis01/bag/metadata/files.xml").toURI).toFile)
 
-    actual should equalTrimmed(expected)
+    actual \ "files" should containAllNodes(expected \ "files")
   }
 
-  // TODO: Fix this test, see EASY-1397
-  ignore should "produce the xml for a deposit with no A/V files" in {
+  it should "produce the xml for a deposit with no A/V files" in {
     val depositId = "ruimtereis02"
     val deposit = testDeposit2.copy(depositId = depositId)
     AddFileMetadataToDeposit(deposit).execute() shouldBe a[Success[_]]
@@ -171,7 +169,7 @@ class AddFileMetadataToDepositSpec extends UnitSpec with BeforeAndAfterEach with
     val actual = XML.loadFile(stagingFileMetadataFile(depositId).toFile)
     val expected = XML.loadFile(Paths.get(getClass.getResource("/allfields/output/input-ruimtereis02/bag/metadata/files.xml").toURI).toFile)
 
-    actual should equalTrimmed(expected)
+    actual \ "files" should containAllNodes(expected \ "files")
   }
 
   it should "produce the xml for a deposit with no files" in {


### PR DESCRIPTION
fixes EASY-1397

#### When applied it will
* fix a bug in the tests with the ordering of xml elements in `files.xml`, caused by differences in ordering in the traversal of a filesystem

@janvanmansum can you run these tests multiple times, such that we're sure that the tests now run correctly? If you still get failing tests, please post them (including the output) in the comments below. Thanks!

@DANS-KNAW/easy for review