### PR TITLE
EASY-1414: Creation timestamp added

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
@@ -20,6 +20,7 @@ import java.{ util => ju }
 
 import nl.knaw.dans.easy.multideposit.model.Deposit
 import nl.knaw.dans.easy.multideposit.{ Action, Settings, _ }
+import org.joda.time.{ DateTime, DateTimeZone }
 import resource._
 
 import scala.language.postfixOps
@@ -69,6 +70,7 @@ case class AddPropertiesToDeposit(deposit: Deposit)(implicit settings: Settings)
     val sf = deposit.audioVideo.springfield
     val props: Map[String, Option[String]] = Map(
       "bag-store.bag-id" -> Some(UUID.randomUUID().toString),
+      "creation.timestamp" -> Some(DateTime.now(DateTimeZone.UTC).toString),
       "state.label" -> Some("SUBMITTED"),
       "state.description" -> Some("Deposit is valid and ready for post-submission processing"),
       "depositor.userId" -> Some(deposit.depositorUserId),

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -81,7 +81,8 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfterEach with M
     props.toFile should exist
 
     props.read() should {
-      include("state.label") and
+      include("creation.timestamp") and
+        include("state.label") and
         include("state.description") and
         include(s"depositor.userId=${ testDeposit1.depositorUserId }") and
         include("datamanager.email=dm@test.org") and
@@ -100,7 +101,8 @@ class AddPropertiesToDepositSpec extends UnitSpec with BeforeAndAfterEach with M
     props.toFile should exist
 
     props.read() should {
-      include("state.label") and
+      include("creation.timestamp") and
+        include("state.label") and
         include("state.description") and
         include("depositor.userId=ruimtereiziger1") and
         include("datamanager.email=dm@test.org") and


### PR DESCRIPTION
fixes EASY-1414

#### When applied it will
* add creation.timestamp to deposit.properties



#### Where should the reviewer @DANS-KNAW/easy start?
I was not able to test since I could not ssh into deasy due to the maintenance in easy,
but this is the only place I can add the creationTimestamp. Therefore it should work properly.

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
