### PR TITLE
EASY-1277 directory pointers with '.' fixed

### DIFF
--- a/clear-run.sh
+++ b/clear-run.sh
@@ -18,6 +18,7 @@
 LOCAL_ARGS=$@
 OUTPUT=data/output
 STAGING=data/staging
+QUIET="-q"
 RUN_SCRIPT=run.sh
 
 ping -t 1 -c 1 test.dans.knaw.nl >/dev/null

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/Command.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.multideposit
 
-import java.nio.file.Paths
+import java.nio.file.{ Path, Paths }
 
 import nl.knaw.dans.easy.multideposit.PathExplorer.PathExplorers
 import nl.knaw.dans.easy.multideposit.actions.{ InvalidDatamanagerException, InvalidInputException }
@@ -51,9 +51,9 @@ object Command extends App with DebugEnhancedLogging {
   private def runSubcommand(app: SplitMultiDepositApp): Try[FeedBackMessage] = {
     lazy val defaultStagingDir = Paths.get(configuration.properties.getString("staging-dir"))
 
-    val md = commandLine.multiDepositDir()
-    val sd = commandLine.stagingDir.getOrElse(defaultStagingDir)
-    val od = commandLine.outputDepositDir()
+    val md = commandLine.multiDepositDir().normalized()
+    val sd = commandLine.stagingDir.getOrElse(defaultStagingDir).normalized()
+    val od = commandLine.outputDepositDir().normalized()
     val dm = commandLine.datamanager()
 
     if (commandLine.validateOnly())

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/package.scala
@@ -177,5 +177,13 @@ package object multideposit {
       managed(Files.walk(path))
         .acquireAndGet(_.iterator().asScala.filter(predicate).toList)
     }
+
+    def normalized(): Path = {
+      val normalized = path.normalize()
+      // if path == "."
+      if (normalized.getFileName.toString.isEmpty)
+        normalized.toAbsolutePath
+      else normalized
+    }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/package.scala
@@ -178,6 +178,17 @@ package object multideposit {
         .acquireAndGet(_.iterator().asScala.filter(predicate).toList)
     }
 
+    /**
+     * Normalize the path and make it absolute. This takes '.' paths into account.
+     *
+     * @example
+     * {{{
+     *   // current path: /foo/bar
+     *   Paths.get(".").normalized() // res: /foo/bar
+     * }}}
+     *
+     * @return
+     */
     def normalized(): Path = {
       val normalized = path.normalize()
       // if path == "."


### PR DESCRIPTION
fixes EASY-1277

#### When applied it will
* process `Paths.get(".")` correctly
* make `./clear-run.sh` run quietly

@DANS-KNAW/easy for review