### PR TITLE
EASY-1511: Let Split Multi Deposit return the base revision UUIDs of the created bags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: java
 jdk: oraclejdk8
+cache:
+  directories:
+    - "$HOME/.m2/repository"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ARGUMENTS
     -s, --staging-dir  <arg>       A directory in which the deposit directories are created, after which they
                                    will be moved to the 'output-deposit-dir'. If not specified, the value of
                                    'staging-dir' in 'application.properties' is used.
-    -v, --validate                 Only validates the input of a Multi-Deposit ingest
+    -v, --validate                 Validates the input of a Multi-Deposit ingest
     -h, --help                     Show help message
         --version                  Show version of this program
   

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Utility to process a Multi-Deposit prior to ingestion into the DANS EASY Archive
 SYNOPSIS
 --------
 
-    easy-split-multi-deposit [{--staging-dir|-s} <dir>] [{--validate|-v}] <multi-deposit-dir> <output-deposits-dir> <datamanager>
+    easy-split-multi-deposit [{--staging-dir|-s} <dir>] [{--identifier-info | -i} <file>] [{--validate|-v}] <multi-deposit-dir> <output-deposits-dir> <datamanager>
 
 
 DESCRIPTION
@@ -48,12 +48,13 @@ ARGUMENTS
 
   Options:
 
-    -s, --staging-dir  <arg>   A directory in which the deposit directories are created, after which they will
-                               be moved to the 'output-deposit-dir'. If not specified, the value of
-                               'staging-dir' in 'application.properties' is used.
-    -v, --validate             Only validates the input of a Multi-Deposit ingest
-    -h, --help                 Show help message
-        --version              Show version of this program
+    -i, --identifier-info  <arg>   CSV file in which information about the created deposits is reported
+    -s, --staging-dir  <arg>       A directory in which the deposit directories are created, after which they
+                                   will be moved to the 'output-deposit-dir'. If not specified, the value of
+                                   'staging-dir' in 'application.properties' is used.
+    -v, --validate                 Only validates the input of a Multi-Deposit ingest
+    -h, --help                     Show help message
+        --version                  Show version of this program
   
    trailing arguments:
     multi-deposit-dir (required)    Directory containing the Submission Information Package to process. This

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/Command.scala
@@ -53,13 +53,14 @@ object Command extends App with DebugEnhancedLogging {
     val md = File(commandLine.multiDepositDir())
     val sd = commandLine.stagingDir.map(File(_)).getOrElse(defaultStagingDir)
     val od = File(commandLine.outputDepositDir())
+    val report = File(commandLine.reportFile())
     val dm = commandLine.datamanager()
 
     if (commandLine.validateOnly())
-      app.validate(new PathExplorers(md, sd, od), dm)
+      app.validate(new PathExplorers(md, sd, od, report), dm)
         .map(_ => "Finished successfully! Everything looks good.")
     else
-      app.convert(new PathExplorers(md, sd, od), dm)
+      app.convert(new PathExplorers(md, sd, od, report), dm)
         .map(_ => s"Finished successfully! The output can be found in $od.")
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/CommandLineOptions.scala
@@ -64,7 +64,7 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
   val validateOnly: ScallopOption[Boolean] = opt[Boolean](
     name = "validate",
     short = 'v',
-    descr = "Only validates the input of a Multi-Deposit ingest",
+    descr = "Validates the input of a Multi-Deposit ingest",
     default = Some(false))
 
   val multiDepositDir: ScallopOption[Path] = trailArg[Path](

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/PathExplorer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/PathExplorer.scala
@@ -20,10 +20,11 @@ import nl.knaw.dans.easy.multideposit.model.DepositId
 
 object PathExplorer {
 
-  class PathExplorers(md: File, sd: File, od: File) extends InputPathExplorer with StagingPathExplorer with OutputPathExplorer {
-    val multiDepositDir: File = md
-    val stagingDir: File = sd
-    val outputDepositDir: File = od
+  class PathExplorers(md: File, sd: File, od: File, report: File) extends InputPathExplorer with StagingPathExplorer with OutputPathExplorer {
+    override val multiDepositDir: File = md
+    override val stagingDir: File = sd
+    override val outputDepositDir: File = od
+    override val reportFile: File = report
   }
 
   trait InputPathExplorer {
@@ -90,6 +91,7 @@ object PathExplorer {
     this: InputPathExplorer =>
 
     val outputDepositDir: File
+    val reportFile: File
 
     // outputDepositDir/mdDir-depositId/
     def outputDepositDir(depositId: DepositId): File = {

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
@@ -38,6 +38,7 @@ class SplitMultiDepositApp(formats: Set[String], ldap: Ldap, permissions: Deposi
   private val fileMetadata = new AddFileMetadataToDeposit()
   private val depositProperties = new AddPropertiesToDeposit()
   private val setPermissions = new SetDepositPermissions(permissions)
+  private val reportDatasets = new ReportDatasets()
   private val moveDeposit = new MoveDepositToOutputDir()
 
   override def close(): Unit = ldap.close()
@@ -71,6 +72,7 @@ class SplitMultiDepositApp(formats: Set[String], ldap: Ldap, permissions: Deposi
         }
       }
       _ = logger.info("deposits were created successfully")
+      _ <- reportDatasets.report(deposits)
       _ <- deposits.mapUntilFailure(d => moveDeposit.moveDepositsToOutputDir(d.depositId))
     } yield ()
   }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
@@ -15,13 +15,11 @@
  */
 package nl.knaw.dans.easy.multideposit.actions
 
-import java.util.{ Collections, Properties, UUID }
-import java.{ util => ju }
-
 import nl.knaw.dans.easy.multideposit.PathExplorer.StagingPathExplorer
-import nl.knaw.dans.easy.multideposit.{ dateTimeFormatter, encoding }
+import nl.knaw.dans.easy.multideposit.dateTimeFormatter
 import nl.knaw.dans.easy.multideposit.model.{ Datamanager, DatamanagerEmailaddress, Deposit }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.apache.commons.configuration.PropertiesConfiguration
 import org.joda.time.{ DateTime, DateTimeZone }
 
 import scala.util.control.NonFatal
@@ -32,22 +30,21 @@ class AddPropertiesToDeposit extends DebugEnhancedLogging {
   def addDepositProperties(deposit: Deposit, datamanagerId: Datamanager, emailaddress: DatamanagerEmailaddress)(implicit stage: StagingPathExplorer): Try[Unit] = {
     logger.debug(s"add deposit properties for ${ deposit.depositId }")
 
-    val props = new Properties {
-      // Make sure we get sorted output, which is better readable than random
-      override def keys(): ju.Enumeration[AnyRef] = Collections.enumeration(new ju.TreeSet[Object](super.keySet()))
+    val props = new PropertiesConfiguration {
+      setDelimiterParsingDisabled(false)
+      setFile(stage.stagingPropertiesFile(deposit.depositId)
+        .createIfNotExists(createParents = true)
+        .toJava)
     }
 
     Try { addProperties(deposit, datamanagerId, emailaddress)(props) }
-      .map(_ => stage.stagingPropertiesFile(deposit.depositId)
-        .createIfNotExists(createParents = true)
-        .bufferedWriter(encoding)
-        .foreach(props.store(_, "")))
+      .map(_ => props.save())
       .recoverWith {
         case NonFatal(e) => Failure(ActionException(s"Could not write properties to file: $e", e))
       }
   }
 
-  private def addProperties(deposit: Deposit, datamanagerId: Datamanager, emailaddress: DatamanagerEmailaddress)(properties: Properties): Unit = {
+  private def addProperties(deposit: Deposit, datamanagerId: Datamanager, emailaddress: DatamanagerEmailaddress)(properties: PropertiesConfiguration): Unit = {
     val sf = deposit.springfield
     val props: Map[String, Option[String]] = Map(
       "bag-store.bag-id" -> Some(deposit.bagId.toString),

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.multideposit.actions
 
 import nl.knaw.dans.easy.multideposit.PathExplorer.StagingPathExplorer
-import nl.knaw.dans.easy.multideposit.dateTimeFormatter
+import nl.knaw.dans.easy.multideposit.now
 import nl.knaw.dans.easy.multideposit.model.{ Datamanager, DatamanagerEmailaddress, Deposit }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
@@ -48,7 +48,7 @@ class AddPropertiesToDeposit extends DebugEnhancedLogging {
     val sf = deposit.springfield
     val props: Map[String, Option[String]] = Map(
       "bag-store.bag-id" -> Some(deposit.bagId.toString),
-      "creation.timestamp" -> Some(DateTime.now(DateTimeZone.UTC).toString(dateTimeFormatter)),
+      "creation.timestamp" -> Some(now),
       "state.label" -> Some("SUBMITTED"),
       "state.description" -> Some("Deposit is valid and ready for post-submission processing"),
       "depositor.userId" -> Some(deposit.depositorUserId),

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
@@ -50,7 +50,7 @@ class AddPropertiesToDeposit extends DebugEnhancedLogging {
   private def addProperties(deposit: Deposit, datamanagerId: Datamanager, emailaddress: DatamanagerEmailaddress)(properties: Properties): Unit = {
     val sf = deposit.springfield
     val props: Map[String, Option[String]] = Map(
-      "bag-store.bag-id" -> Some(UUID.randomUUID().toString),
+      "bag-store.bag-id" -> Some(deposit.bagId.toString),
       "creation.timestamp" -> Some(DateTime.now(DateTimeZone.UTC).toString(dateTimeFormatter)),
       "state.label" -> Some("SUBMITTED"),
       "state.description" -> Some("Deposit is valid and ready for post-submission processing"),

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ReportDatasets.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ReportDatasets.scala
@@ -34,7 +34,7 @@ class ReportDatasets {
 
   private def csvPrinter(file: File): ManagedResource[CSVPrinter] = {
     file.bufferedWriter(charset = encoding)
-      .flatMap[CSVPrinter, ManagedResource](writer => new ManagedResource(new CSVPrinter(writer, csvFormat)))
+      .flatMap[CSVPrinter, ManagedResource](writer => new ManagedResource(csvFormat.print(writer)))
   }
 
   private def printRecord(deposit: Deposit, printer: CSVPrinter): Unit = {

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ReportDatasets.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ReportDatasets.scala
@@ -1,14 +1,51 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.multideposit.actions
 
+import better.files.{ ManagedResource, _ }
 import nl.knaw.dans.easy.multideposit.PathExplorer.OutputPathExplorer
+import nl.knaw.dans.easy.multideposit.actions.ReportDatasets._
+import nl.knaw.dans.easy.multideposit.encoding
 import nl.knaw.dans.easy.multideposit.model.Deposit
+import org.apache.commons.csv.{ CSVFormat, CSVPrinter }
 
 import scala.util.Try
 
 class ReportDatasets {
 
   def report(deposits: Seq[Deposit])(implicit output: OutputPathExplorer): Try[Unit] = Try {
-    // TODO implement
-    println(output.reportFile)
+    for(printer <- csvPrinter(output.reportFile);
+        deposit <- deposits)
+      printRecord(deposit, printer)
   }
+
+  private def csvPrinter(file: File): ManagedResource[CSVPrinter] = {
+    file.bufferedWriter(charset = encoding)
+      .flatMap[CSVPrinter, ManagedResource](writer => new ManagedResource(new CSVPrinter(writer, csvFormat)))
+  }
+
+  private def printRecord(deposit: Deposit, printer: CSVPrinter): Unit = {
+    printer.printRecord(
+      deposit.depositId,
+      deposit.bagId,
+      deposit.baseUUID.getOrElse(deposit.bagId)
+    )
+  }
+}
+
+object ReportDatasets {
+  private val csvFormat = CSVFormat.RFC4180.withHeader("DATASET", "UUID", "BASE-REVISION")
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ReportDatasets.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ReportDatasets.scala
@@ -1,0 +1,14 @@
+package nl.knaw.dans.easy.multideposit.actions
+
+import nl.knaw.dans.easy.multideposit.PathExplorer.OutputPathExplorer
+import nl.knaw.dans.easy.multideposit.model.Deposit
+
+import scala.util.Try
+
+class ReportDatasets {
+
+  def report(deposits: Seq[Deposit])(implicit output: OutputPathExplorer): Try[Unit] = Try {
+    // TODO implement
+    println(output.reportFile)
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/model/Deposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/model/Deposit.scala
@@ -27,14 +27,15 @@ case class Instructions(depositId: DepositId,
                         metadata: Metadata = Metadata(),
                         files: Map[File, FileDescriptor] = Map.empty,
                         audioVideo: AudioVideo = AudioVideo()) {
-  def toDeposit(fms: Seq[FileMetadata] = Seq.empty): Deposit = {
-    Deposit(depositId = depositId,
+  def toDeposit(fileMetadatas: Seq[FileMetadata] = Seq.empty): Deposit = {
+    Deposit(
+      depositId = depositId,
+      baseUUID = baseUUID,
       row = row,
       depositorUserId = depositorUserId,
       profile = profile,
-      baseUUID = baseUUID,
       metadata = metadata,
-      files = fms,
+      files = fileMetadatas,
       springfield = audioVideo.springfield
     )
   }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/model/Deposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/model/Deposit.scala
@@ -15,26 +15,37 @@
  */
 package nl.knaw.dans.easy.multideposit.model
 
+import java.util.UUID
+
 import better.files.File
 
 case class Instructions(depositId: DepositId,
                         row: Int,
                         depositorUserId: DepositorUserId,
                         profile: Profile,
-                        baseUUID: Option[BaseUUID]= Option.empty,
+                        baseUUID: Option[BaseUUID] = Option.empty,
                         metadata: Metadata = Metadata(),
                         files: Map[File, FileDescriptor] = Map.empty,
                         audioVideo: AudioVideo = AudioVideo()) {
   def toDeposit(fms: Seq[FileMetadata] = Seq.empty): Deposit = {
-    Deposit(depositId, row, depositorUserId, profile, baseUUID, metadata, fms, audioVideo.springfield)
+    Deposit(depositId = depositId,
+      row = row,
+      depositorUserId = depositorUserId,
+      profile = profile,
+      baseUUID = baseUUID,
+      metadata = metadata,
+      files = fms,
+      springfield = audioVideo.springfield
+    )
   }
 }
 
 case class Deposit(depositId: DepositId,
+                   bagId: BagId = UUID.randomUUID(),
+                   baseUUID: Option[BaseUUID] = Option.empty,
                    row: Int,
                    depositorUserId: DepositorUserId,
                    profile: Profile,
-                   baseUUID: Option[BaseUUID]= Option.empty,
                    metadata: Metadata = Metadata(),
                    files: Seq[FileMetadata] = Seq.empty,
                    springfield: Option[Springfield] = Option.empty)

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/model/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/model/package.scala
@@ -27,6 +27,7 @@ package object model {
   type MimeType = String
   type Datamanager = String
   type DatamanagerEmailaddress = String
+  type BagId = UUID
   type BaseUUID = UUID
 
   // inspired by http://stackoverflow.com/questions/28223692/what-is-the-optimal-way-not-using-scalaz-to-type-require-a-non-empty-list

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/package.scala
@@ -20,6 +20,7 @@ import java.nio.charset.Charset
 
 import better.files.File
 import org.apache.commons.io.Charsets
+import org.joda.time.{ DateTime, DateTimeZone }
 import org.joda.time.format.{ DateTimeFormatter, ISODateTimeFormat }
 
 import scala.collection.generic.CanBuildFrom
@@ -28,6 +29,7 @@ import scala.xml.{ Elem, PrettyPrinter, Utility, XML }
 
 package object multideposit {
   val dateTimeFormatter: DateTimeFormatter = ISODateTimeFormat.dateTime()
+  def now: String = DateTime.now(DateTimeZone.UTC).toString(dateTimeFormatter)
 
   val encoding: Charset = Charsets.UTF_8
 

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -45,8 +45,8 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
     formats should contain("audio/mpeg3")
   }
 
-  private val allfields = testDir / "md" / "allfields"
-  private val invalidCSV = testDir / "md" / "invalidCSV"
+  private val allfields = multiDepositDir / "allfields"
+  private val invalidCSV = multiDepositDir / "invalidCSV"
 
   /*
     Note to future developers:
@@ -82,8 +82,10 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
     val datamanager = "easyadmin"
     val paths = new PathExplorers(
       md = allfields,
-      sd = testDir / "sd",
-      od = (testDir / "od").createIfNotExists(asDirectory = true, createParents = true))
+      sd = stagingDir,
+      od = outputDepositDir.createIfNotExists(asDirectory = true, createParents = true),
+      report = reportFile
+    )
     val app = new SplitMultiDepositApp(formats, ldap, DepositPermissions("rwxrwx---", getFileSystemGroup))
 
     val expectedOutputDir = File(getClass.getResource("/allfields/output").toURI)
@@ -290,8 +292,10 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
   "convert invalidCSV" should "fail in the parser step and return a report of the errors" in {
     val paths = new PathExplorers(
       md = invalidCSV,
-      sd = testDir / "sd",
-      od = (testDir / "od").createIfNotExists(asDirectory = true, createParents = true))
+      sd = stagingDir,
+      od = outputDepositDir.createIfNotExists(asDirectory = true, createParents = true),
+      report = reportFile
+    )
     val app = new SplitMultiDepositApp(formats, mock[Ldap], DepositPermissions("rwxrwx---", getFileSystemGroup))
 
     inside(app.convert(paths, "easyadmin")) {

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -285,6 +285,8 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
     }
 
     it should "check report.csv" in {
+      doNotRunOnTravis()
+      
       reportFile.toJava should exist
 
       val header :: lines = reportFile.lines.toList

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -48,6 +48,11 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
   private val allfields = multiDepositDir / "allfields"
   private val invalidCSV = multiDepositDir / "invalidCSV"
 
+  val ruimtereis01 = "ruimtereis01"
+  val ruimtereis02 = "ruimtereis02"
+  val ruimtereis03 = "ruimtereis03"
+  val ruimtereis04 = "ruimtereis04"
+
   /*
     Note to future developers:
     We're sharing tests in this BlackBoxSpec to prevent as much test duplication as possible.
@@ -279,10 +284,30 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       }
     }
 
-    "ruimtereis01" should behave like bagContents("ruimtereis01", expectedDataContentRuimtereis01)
-    "ruimtereis02" should behave like bagContents("ruimtereis02", expectedDataContentRuimtereis02)
-    "ruimtereis03" should behave like bagContents("ruimtereis03", expectedDataContentRuimtereis03)
-    "ruimtereis04" should behave like bagContents("ruimtereis04", expectedDataContentRuimtereis04)
+    it should "check report.csv" in {
+      reportFile.toJava should exist
+
+      val header :: lines = reportFile.lines.toList
+      val reportLines = lines.collect {
+        case s if s startsWith ruimtereis01 => ruimtereis01 -> s
+        case s if s startsWith ruimtereis02 => ruimtereis02 -> s
+        case s if s startsWith ruimtereis03 => ruimtereis03 -> s
+        case s if s startsWith ruimtereis04 => ruimtereis04 -> s
+      }.toMap
+      // taken from https://stackoverflow.com/a/6640851/2389405
+      val uuidRegex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+      header shouldBe "DATASET,UUID,BASE-REVISION"
+      reportLines(ruimtereis01) should fullyMatch regex s"^$ruimtereis01,$uuidRegex,d5e8f0fb-c374-86eb-918c-b06dd5ae5e71$$"
+      reportLines(ruimtereis02) should fullyMatch regex s"^$ruimtereis02,($uuidRegex),\\1$$"
+      reportLines(ruimtereis03) should fullyMatch regex s"^$ruimtereis03,($uuidRegex),\\1$$"
+      reportLines(ruimtereis04) should fullyMatch regex s"^$ruimtereis04,$uuidRegex,773dc53a-1cdb-47c4-992a-254a59b98376$$"
+    }
+
+    ruimtereis01 should behave like bagContents(ruimtereis01, expectedDataContentRuimtereis01)
+    ruimtereis02 should behave like bagContents(ruimtereis02, expectedDataContentRuimtereis02)
+    ruimtereis03 should behave like bagContents(ruimtereis03, expectedDataContentRuimtereis03)
+    ruimtereis04 should behave like bagContents(ruimtereis04, expectedDataContentRuimtereis04)
   }
 
   beforeAll()

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -286,7 +286,7 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
 
     it should "check report.csv" in {
       doNotRunOnTravis()
-      
+
       reportFile.toJava should exist
 
       val header :: lines = reportFile.lines.toList
@@ -297,7 +297,8 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
         case s if s startsWith ruimtereis04 => ruimtereis04 -> s
       }.toMap
       // taken from https://stackoverflow.com/a/6640851/2389405
-      val uuidRegex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+      // and https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/111#discussion_r194733478
+      val uuidRegex = "[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}"
 
       header shouldBe "DATASET,UUID,BASE-REVISION"
       reportLines(ruimtereis01) should fullyMatch regex s"^$ruimtereis01,$uuidRegex,d5e8f0fb-c374-86eb-918c-b06dd5ae5e71$$"

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/TestSupportFixture.scala
@@ -36,6 +36,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with OptionValues with I
   override val multiDepositDir: File = testDir / "md"
   override val stagingDir: File = testDir / "sd"
   override val outputDepositDir: File = testDir / "od"
+  override val reportFile: File = testDir / "report.csv"
 
   implicit val inputPathExplorer: InputPathExplorer = this
   implicit val stagingPathExplorer: StagingPathExplorer = this

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ReportDatasetsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ReportDatasetsSpec.scala
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.multideposit.actions
+
+import java.util.UUID
+
+import nl.knaw.dans.easy.multideposit.TestSupportFixture
+import org.scalatest.BeforeAndAfterEach
+
+class ReportDatasetsSpec extends TestSupportFixture with BeforeAndAfterEach {
+
+  private val action = new ReportDatasets
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    if (outputPathExplorer.reportFile.exists)
+      outputPathExplorer.reportFile.delete()
+  }
+
+  "report" should "list the depositId, bagId and baseId for all deposits in a multi-deposit" in {
+    val depositId1 = "deposit1"
+    val depositId2 = "deposit2"
+
+    val bagId1 = UUID.randomUUID()
+    val bagId2 = UUID.randomUUID()
+
+    val baseId1 = UUID.randomUUID()
+    val baseId2 = UUID.randomUUID()
+
+    val deposits = Seq(
+      testInstructions1.toDeposit().copy(depositId = depositId1, bagId = bagId1, baseUUID = Some(baseId1)),
+      testInstructions1.toDeposit().copy(depositId = depositId2, bagId = bagId2, baseUUID = Some(baseId2))
+    )
+
+    outputPathExplorer.reportFile.toJava shouldNot exist
+
+    action.report(deposits)
+
+    outputPathExplorer.reportFile.toJava should exist
+    outputPathExplorer.reportFile.lines.toList should contain inOrderOnly(
+      "DATASET,UUID,BASE-REVISION",
+      s"$depositId1,$bagId1,$baseId1",
+      s"$depositId2,$bagId2,$baseId2"
+    )
+  }
+
+  it should "list use the bagId as baseId when this is not a new revision of an earlier dataset" in {
+    val depositId1 = "deposit1"
+    val depositId2 = "deposit2"
+
+    val bagId1 = UUID.randomUUID()
+    val bagId2 = UUID.randomUUID()
+
+    val baseId1 = UUID.randomUUID()
+
+    val deposits = Seq(
+      testInstructions1.toDeposit().copy(depositId = depositId1, bagId = bagId1, baseUUID = Some(baseId1)),
+      // baseUUID = None, causes bagId2 to be used in the CSV instead
+      testInstructions1.toDeposit().copy(depositId = depositId2, bagId = bagId2, baseUUID = None)
+    )
+
+    outputPathExplorer.reportFile.toJava shouldNot exist
+
+    action.report(deposits)
+
+    outputPathExplorer.reportFile.toJava should exist
+    outputPathExplorer.reportFile.lines.toList should contain inOrderOnly(
+      "DATASET,UUID,BASE-REVISION",
+      s"$depositId1,$bagId1,$baseId1",
+      s"$depositId2,$bagId2,$bagId2"
+    )
+  }
+}


### PR DESCRIPTION
fixes EASY-1511

#### When applied it will
* create a CSV report of all deposits that are created using this bulk tool
* add commandline option `--identifier-info` or `-i` to configure the name/location of the report to be created (default to `<user home>/easy-split-multi-deposit-identifier-info-<current-timestamp>.csv`

@DANS-KNAW/easy for review