### PR TITLE
EASY-1584: Use UUID as the directory name

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.multideposit/PathExplorer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/PathExplorer.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.multideposit
 
 import better.files.File
-import nl.knaw.dans.easy.multideposit.model.DepositId
+import nl.knaw.dans.easy.multideposit.model.{ BagId, DepositId }
 
 object PathExplorer {
 
@@ -50,6 +50,10 @@ object PathExplorer {
     val datasetMetadataFileName = "dataset.xml"
     val fileMetadataFileName = "files.xml"
     val propsFileName = "deposit.properties"
+
+    private def datasetDir(multiDepositDir: File, depositId: DepositId): String = {
+      s"${ multiDepositDir.name }-$depositId"
+    }
 
     // stagingDir/mdDir-depositId/
     def stagingDir(depositId: DepositId): File = {
@@ -93,9 +97,9 @@ object PathExplorer {
     val outputDepositDir: File
     val reportFile: File
 
-    // outputDepositDir/mdDir-depositId/
-    def outputDepositDir(depositId: DepositId): File = {
-      outputDepositDir / datasetDir(multiDepositDir, depositId)
+    // outputDepositDir/bagId/
+    def outputDepositDir(bagId: BagId): File = {
+      outputDepositDir / bagId.toString
     }
   }
 
@@ -103,9 +107,5 @@ object PathExplorer {
 
   def multiDepositInstructionsFile(baseDir: File): File = {
     baseDir / instructionsFileName
-  }
-
-  private def datasetDir(multiDepositDir: File, depositId: DepositId): String = {
-    s"${ multiDepositDir.name }-$depositId"
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
@@ -16,9 +16,9 @@
 package nl.knaw.dans.easy.multideposit
 
 import java.util.Locale
+
 import javax.naming.Context
 import javax.naming.ldap.InitialLdapContext
-
 import nl.knaw.dans.easy.multideposit.PathExplorer._
 import nl.knaw.dans.easy.multideposit.actions.{ RetrieveDatamanager, _ }
 import nl.knaw.dans.easy.multideposit.model.{ Datamanager, DatamanagerEmailaddress, Deposit }
@@ -73,7 +73,9 @@ class SplitMultiDepositApp(formats: Set[String], ldap: Ldap, permissions: Deposi
       }
       _ = logger.info("deposits were created successfully")
       _ <- reportDatasets.report(deposits)
+      _ = logger.info("report generated")
       _ <- deposits.mapUntilFailure(deposit => moveDeposit.moveDepositsToOutputDir(deposit.depositId, deposit.bagId))
+      _ = logger.info(s"deposits were successfully moved to ${ output.outputDepositDir }")
     } yield ()
   }
 
@@ -94,7 +96,7 @@ class SplitMultiDepositApp(formats: Set[String], ldap: Ldap, permissions: Deposi
       _ <- fileMetadata.addFileMetadata(depositId, deposit.files)
       _ <- depositProperties.addDepositProperties(deposit, datamanagerId, dataManagerEmailAddress)
       _ <- setPermissions.setDepositPermissions(depositId)
-      _ = logger.info(s"deposit was created successfully for $depositId")
+      _ = logger.info(s"deposit was created successfully for $depositId with bagId ${ deposit.bagId }")
     } yield ()
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
@@ -73,7 +73,7 @@ class SplitMultiDepositApp(formats: Set[String], ldap: Ldap, permissions: Deposi
       }
       _ = logger.info("deposits were created successfully")
       _ <- reportDatasets.report(deposits)
-      _ <- deposits.mapUntilFailure(d => moveDeposit.moveDepositsToOutputDir(d.depositId))
+      _ <- deposits.mapUntilFailure(deposit => moveDeposit.moveDepositsToOutputDir(deposit.depositId, deposit.bagId))
     } yield ()
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/MoveDepositToOutputDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/MoveDepositToOutputDir.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.multideposit.actions
 
 import nl.knaw.dans.easy.multideposit.PathExplorer.{ OutputPathExplorer, StagingPathExplorer }
-import nl.knaw.dans.easy.multideposit.model.DepositId
+import nl.knaw.dans.easy.multideposit.model.{ BagId, DepositId }
 import nl.knaw.dans.lib.error.CompositeException
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
@@ -24,9 +24,9 @@ import scala.util.{ Failure, Success, Try }
 
 class MoveDepositToOutputDir extends DebugEnhancedLogging {
 
-  def moveDepositsToOutputDir(depositId: DepositId)(implicit stage: StagingPathExplorer, output: OutputPathExplorer): Try[Unit] = {
+  def moveDepositsToOutputDir(depositId: DepositId, bagId: BagId)(implicit stage: StagingPathExplorer, output: OutputPathExplorer): Try[Unit] = {
     val stagingDirectory = stage.stagingDir(depositId)
-    val outputDir = output.outputDepositDir(depositId)
+    val outputDir = output.outputDepositDir(bagId)
 
     logger.debug(s"moving $stagingDirectory to $outputDir")
 

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditions.scala
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy.multideposit.actions
 import better.files.File
 import nl.knaw.dans.easy.multideposit.Ldap
 import nl.knaw.dans.easy.multideposit.PathExplorer.{ OutputPathExplorer, StagingPathExplorer }
-import nl.knaw.dans.easy.multideposit.model.{ AVFileMetadata, Deposit, DepositId }
+import nl.knaw.dans.easy.multideposit.model.{ AVFileMetadata, BagId, Deposit, DepositId }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.util.{ Failure, Success, Try }
@@ -30,7 +30,7 @@ class ValidatePreconditions(ldap: Ldap) extends DebugEnhancedLogging {
     logger.debug(s"validating deposit $id")
     for {
       _ <- checkDirectoriesDoNotExist(id)(stage.stagingDir(id), stage.stagingBagDir(id), stage.stagingBagMetadataDir(id))
-      _ <- checkOutputDirectoryExists(id)
+      _ <- checkOutputDirectoryExists(deposit.bagId, id)
       _ <- checkSpringFieldDepositHasAVformat(deposit)
       _ <- checkSFColumnsIfDepositContainsAVFiles(deposit)
       _ <- checkEitherVideoOrAudio(deposit)
@@ -46,10 +46,10 @@ class ValidatePreconditions(ldap: Ldap) extends DebugEnhancedLogging {
       .getOrElse(Success(()))
   }
 
-  def checkOutputDirectoryExists(depositId: DepositId)(implicit output: OutputPathExplorer): Try[Unit] = {
+  def checkOutputDirectoryExists(bagId: BagId, depositId: DepositId)(implicit output: OutputPathExplorer): Try[Unit] = {
     logger.debug("check output directory does exist")
 
-    Try { output.outputDepositDir(depositId).exists }
+    Try { output.outputDepositDir(bagId).exists }
       .flatMap {
         case true => Failure(ActionException(s"The deposit for dataset $depositId already exists in ${ output.outputDepositDir }"))
         case false => Success(())

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditions.scala
@@ -30,7 +30,6 @@ class ValidatePreconditions(ldap: Ldap) extends DebugEnhancedLogging {
     logger.debug(s"validating deposit $id")
     for {
       _ <- checkDirectoriesDoNotExist(id)(stage.stagingDir(id), stage.stagingBagDir(id), stage.stagingBagMetadataDir(id))
-      _ <- checkOutputDirectoryExists(deposit.bagId, id)
       _ <- checkSpringFieldDepositHasAVformat(deposit)
       _ <- checkSFColumnsIfDepositContainsAVFiles(deposit)
       _ <- checkEitherVideoOrAudio(deposit)
@@ -44,16 +43,6 @@ class ValidatePreconditions(ldap: Ldap) extends DebugEnhancedLogging {
     directories.find(_.exists)
       .map(file => Failure(ActionException(s"The deposit for dataset $depositId already exists in $file.")))
       .getOrElse(Success(()))
-  }
-
-  def checkOutputDirectoryExists(bagId: BagId, depositId: DepositId)(implicit output: OutputPathExplorer): Try[Unit] = {
-    logger.debug("check output directory does exist")
-
-    Try { output.outputDepositDir(bagId).exists }
-      .flatMap {
-        case true => Failure(ActionException(s"The deposit for dataset $depositId already exists in ${ output.outputDepositDir }"))
-        case false => Success(())
-      }
   }
 
   def checkSpringFieldDepositHasAVformat(deposit: Deposit): Try[Unit] = {

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/CustomMatchers.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/CustomMatchers.scala
@@ -51,35 +51,4 @@ trait CustomMatchers {
     }
   }
   def equalTrimmed(right: Iterable[Node]) = new EqualTrimmedMatcher(right)
-
-  class ContainAllTrimmed(right: Iterable[Node]) extends Matcher[Iterable[Node]] {
-    override def apply(left: Iterable[Node]): MatchResult = {
-      MatchResult(
-        {
-          left.size == right.size && left.map(l => right.exists(l ==)).forall(true ==)
-        },
-        // TODO showing the diffs should be done better, but I don't know yet how to use the IntelliJ supported solution to get a nice diff
-        // need to look deeper into that.
-        s"$left did not contain the same elements as $right: ${ missingLeft(left, right) }; ${ missingRight(left, right) }",
-        s"$left did contain the same elements as $right"
-      )
-    }
-
-    private def missingLeft(left: Iterable[Node], right: Iterable[Node]) = {
-      val diff = right.toList diff left.toList
-      diff match {
-        case Nil => ""
-        case _ => s"Missing in left: ${ diff.mkString("[", ", ", "]") }"
-      }
-    }
-
-    private def missingRight(left: Iterable[Node], right: Iterable[Node]) = {
-      val diff = left.toList diff right.toList
-      diff match {
-        case Nil => ""
-        case _ => s"Missing in right: ${ diff.mkString("[", ", ", "]") }"
-      }
-    }
-  }
-  def containAllNodes(right: Iterable[Node]) = new ContainAllTrimmed(right)
 }

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -146,6 +146,18 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       reportLines(ruimtereis04) should fullyMatch regex s"^$ruimtereis04,$uuidRegex,773dc53a-1cdb-47c4-992a-254a59b98376$$"
     }
 
+    def extractBagId(s: String) = {
+      s"^.*,($uuidRegex),.*$$".r.findFirstMatchIn(s).map(_.group(1))
+        .getOrElse { fail(s"""report output line "$s" does not match the expected pattern""") }
+    }
+
+    lazy val bagIdsPerDeposit = reportFile.lines.drop(1).collect {
+      case s if s startsWith ruimtereis01 => ruimtereis01 -> extractBagId(s)
+      case s if s startsWith ruimtereis02 => ruimtereis02 -> extractBagId(s)
+      case s if s startsWith ruimtereis03 => ruimtereis03 -> extractBagId(s)
+      case s if s startsWith ruimtereis04 => ruimtereis04 -> extractBagId(s)
+    }.toMap
+
     val expectedDataContentRuimtereis01 = Set("data/", "ruimtereis01_verklaring.txt", "path/",
       "to/", "a/", "random/", "video/", "hubble.mpg", "reisverslag/", "centaur.mpg", "centaur.srt",
       "centaur-nederlands.srt", "deel01.docx", "deel01.txt", "deel02.txt", "deel03.txt")

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -122,6 +122,30 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       app.convert(paths, datamanager) shouldBe a[Success[_]]
     }
 
+    val uuidRegex = "[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}"
+
+    it should "check report.csv" in {
+      doNotRunOnTravis()
+
+      reportFile.toJava should exist
+
+      val header :: lines = reportFile.lines.toList
+      val reportLines = lines.collect {
+        case s if s startsWith ruimtereis01 => ruimtereis01 -> s
+        case s if s startsWith ruimtereis02 => ruimtereis02 -> s
+        case s if s startsWith ruimtereis03 => ruimtereis03 -> s
+        case s if s startsWith ruimtereis04 => ruimtereis04 -> s
+      }.toMap
+      // taken from https://stackoverflow.com/a/6640851/2389405
+      // and https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/111#discussion_r194733478
+
+      header shouldBe "DATASET,UUID,BASE-REVISION"
+      reportLines(ruimtereis01) should fullyMatch regex s"^$ruimtereis01,$uuidRegex,d5e8f0fb-c374-86eb-918c-b06dd5ae5e71$$"
+      reportLines(ruimtereis02) should fullyMatch regex s"^$ruimtereis02,($uuidRegex),\\1$$"
+      reportLines(ruimtereis03) should fullyMatch regex s"^$ruimtereis03,($uuidRegex),\\1$$"
+      reportLines(ruimtereis04) should fullyMatch regex s"^$ruimtereis04,$uuidRegex,773dc53a-1cdb-47c4-992a-254a59b98376$$"
+    }
+
     val expectedDataContentRuimtereis01 = Set("data/", "ruimtereis01_verklaring.txt", "path/",
       "to/", "a/", "random/", "video/", "hubble.mpg", "reisverslag/", "centaur.mpg", "centaur.srt",
       "centaur-nederlands.srt", "deel01.docx", "deel01.txt", "deel02.txt", "deel03.txt")
@@ -282,29 +306,6 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
         noException should be thrownBy DateTime.parse(props.getString("creation.timestamp"), dateTimeFormatter)
         noException should be thrownBy DateTime.parse(expProps.getString("creation.timestamp"), dateTimeFormatter)
       }
-    }
-
-    it should "check report.csv" in {
-      doNotRunOnTravis()
-
-      reportFile.toJava should exist
-
-      val header :: lines = reportFile.lines.toList
-      val reportLines = lines.collect {
-        case s if s startsWith ruimtereis01 => ruimtereis01 -> s
-        case s if s startsWith ruimtereis02 => ruimtereis02 -> s
-        case s if s startsWith ruimtereis03 => ruimtereis03 -> s
-        case s if s startsWith ruimtereis04 => ruimtereis04 -> s
-      }.toMap
-      // taken from https://stackoverflow.com/a/6640851/2389405
-      // and https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/111#discussion_r194733478
-      val uuidRegex = "[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}"
-
-      header shouldBe "DATASET,UUID,BASE-REVISION"
-      reportLines(ruimtereis01) should fullyMatch regex s"^$ruimtereis01,$uuidRegex,d5e8f0fb-c374-86eb-918c-b06dd5ae5e71$$"
-      reportLines(ruimtereis02) should fullyMatch regex s"^$ruimtereis02,($uuidRegex),\\1$$"
-      reportLines(ruimtereis03) should fullyMatch regex s"^$ruimtereis03,($uuidRegex),\\1$$"
-      reportLines(ruimtereis04) should fullyMatch regex s"^$ruimtereis04,$uuidRegex,773dc53a-1cdb-47c4-992a-254a59b98376$$"
     }
 
     ruimtereis01 should behave like bagContents(ruimtereis01, expectedDataContentRuimtereis01)

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -122,6 +122,8 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       app.convert(paths, datamanager) shouldBe a[Success[_]]
     }
 
+    // taken from https://stackoverflow.com/a/6640851/2389405
+    // and https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/111#discussion_r194733478
     val uuidRegex = "[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}"
 
     it should "check report.csv" in {
@@ -136,8 +138,6 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
         case s if s startsWith ruimtereis03 => ruimtereis03 -> s
         case s if s startsWith ruimtereis04 => ruimtereis04 -> s
       }.toMap
-      // taken from https://stackoverflow.com/a/6640851/2389405
-      // and https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/111#discussion_r194733478
 
       header shouldBe "DATASET,UUID,BASE-REVISION"
       reportLines(ruimtereis01) should fullyMatch regex s"^$ruimtereis01,$uuidRegex,d5e8f0fb-c374-86eb-918c-b06dd5ae5e71$$"

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -167,9 +167,9 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
     val expectedDataContentRuimtereis04 = Set("data/", "Quicksort.hs", "path/", "to/", "a/",
       "random/", "file/", "file.txt", "sound/", "chicken.mp3")
 
-    def bagContents(bagName: String, dataContent: Set[String]): Unit = {
-      val bag = paths.outputDepositDir / s"allfields-$bagName/bag"
-      val expBag = expectedOutputDir / s"input-$bagName/bag"
+    def bagContents(depositName: String, dataContent: Set[String]): Unit = {
+      lazy val bag = paths.outputDepositDir / bagIdsPerDeposit(depositName) / "bag"
+      val expBag = expectedOutputDir / s"input-$depositName" / "bag"
 
       it should "check the files present in the bag" in {
         doNotRunOnTravis()
@@ -294,11 +294,11 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
 
         val props = new PropertiesConfiguration() {
           setDelimiterParsingDisabled(true)
-          load(paths.outputDepositDir / s"allfields-$bagName" / "deposit.properties" toJava)
+          load(paths.outputDepositDir / bagIdsPerDeposit(depositName) / "deposit.properties" toJava)
         }
         val expProps = new PropertiesConfiguration() {
           setDelimiterParsingDisabled(true)
-          load(expectedOutputDir / s"input-$bagName" / "deposit.properties" toJava)
+          load(expectedOutputDir / s"input-$depositName" / "deposit.properties" toJava)
         }
 
         props.getKeys.asScala.toSet should contain theSameElementsAs expProps.getKeys.asScala.toSet

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddFileMetadataToDepositSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddFileMetadataToDepositSpec.scala
@@ -85,7 +85,7 @@ class AddFileMetadataToDepositSpec extends TestSupportFixture with CustomMatcher
     val actual = XML.loadFile(stagingFileMetadataFile(depositId).toJava)
     val expected = XML.loadFile(File(getClass.getResource("/allfields/output/input-ruimtereis01/bag/metadata/files.xml").toURI).toJava)
 
-    actual \ "files" should containAllNodes(expected \ "files")
+    actual \ "files" should contain theSameElementsAs (expected \ "files")
   }
 
   it should "produce the xml for a deposit with no A/V files" in {
@@ -103,7 +103,7 @@ class AddFileMetadataToDepositSpec extends TestSupportFixture with CustomMatcher
     val actual = XML.loadFile(stagingFileMetadataFile(depositId).toJava)
     val expected = XML.loadFile(File(getClass.getResource("/allfields/output/input-ruimtereis02/bag/metadata/files.xml").toURI).toJava)
 
-    actual \ "files" should containAllNodes(expected \ "files")
+    actual \ "files" should contain theSameElementsAs (expected \ "files")
   }
 
   it should "produce the xml for a deposit with no files" in {

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/MoveDepositToOutputDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/MoveDepositToOutputDirSpec.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.multideposit.actions
 
+import java.util.UUID
+
 import better.files.File
 import nl.knaw.dans.easy.multideposit.TestSupportFixture
 import org.scalatest.BeforeAndAfterEach
@@ -23,7 +25,8 @@ import scala.util.Success
 
 class MoveDepositToOutputDirSpec extends TestSupportFixture with BeforeAndAfterEach {
 
-  private val depositId = "ruimtereis01"
+  private val depositId1 = "ruimtereis01"
+  private val depositId2 = "ruimtereis02"
   private val action = new MoveDepositToOutputDir
 
   override def beforeEach(): Unit = {
@@ -35,12 +38,12 @@ class MoveDepositToOutputDirSpec extends TestSupportFixture with BeforeAndAfterE
     stagingDir.toJava should exist
 
     File(getClass.getResource("/allfields/output/input-ruimtereis01").toURI)
-      .copyTo(stagingDir("ruimtereis01"))
+      .copyTo(stagingDir(depositId1))
     File(getClass.getResource("/allfields/output/input-ruimtereis02").toURI)
-      .copyTo(stagingDir("ruimtereis02"))
+      .copyTo(stagingDir(depositId2))
 
-    stagingDir("ruimtereis01").toJava should exist
-    stagingDir("ruimtereis02").toJava should exist
+    stagingDir(depositId1).toJava should exist
+    stagingDir(depositId2).toJava should exist
 
     if (outputDepositDir.exists) outputDepositDir.delete()
     outputDepositDir.createDirectory()
@@ -48,19 +51,21 @@ class MoveDepositToOutputDirSpec extends TestSupportFixture with BeforeAndAfterE
   }
 
   "execute" should "move the deposit to the outputDepositDirectory" in {
-    action.moveDepositsToOutputDir(depositId) shouldBe a[Success[_]]
+    val bagId = UUID.randomUUID()
 
-    stagingDir(depositId).toJava shouldNot exist
-    outputDepositDir(depositId).toJava should exist
+    action.moveDepositsToOutputDir(depositId1, bagId) shouldBe a[Success[_]]
 
-    stagingDir("ruimtereis02").toJava should exist
-    outputDepositDir("ruimtereis02").toJava shouldNot exist
+    stagingDir(depositId1).toJava shouldNot exist
+    outputDepositDir(bagId).toJava should exist
   }
 
   it should "only move the one deposit to the outputDepositDirectory, not other deposits in the staging directory" in {
-    action.moveDepositsToOutputDir(depositId) shouldBe a[Success[_]]
+    val bagId = UUID.randomUUID()
 
-    stagingDir("ruimtereis02").toJava should exist
-    outputDepositDir("ruimtereis02").toJava shouldNot exist
+    action.moveDepositsToOutputDir(depositId1, bagId) shouldBe a[Success[_]]
+
+    stagingDir(depositId2).toJava should exist
+    // even though ruimtereis02 is staged as well, it is not moved to the outputDepositDir
+    outputDepositDir.list.toList should contain only outputDepositDir(bagId)
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
@@ -15,8 +15,6 @@
  */
 package nl.knaw.dans.easy.multideposit.actions
 
-import java.util.UUID
-
 import better.files.File
 import better.files.File.currentWorkingDirectory
 import javax.naming.directory.Attributes
@@ -63,22 +61,6 @@ class ValidatePreconditionsSpec extends TestSupportFixture with BeforeAndAfterEa
     dir.toJava should exist
 
     inside(action.checkDirectoriesDoNotExist(depositId)(dir)) {
-      case Failure(ActionException(msg, _)) => msg should include(s"The deposit for dataset $depositId already exists")
-    }
-  }
-
-  "checkPreconditions" should "verify that the deposit does not yet exist in the outputDepositDir" in {
-    val bagId = UUID.randomUUID()
-    action.checkOutputDirectoryExists(bagId, "ruimtereis01") shouldBe a[Success[_]]
-  }
-
-  it should "fail if the deposit already exists in the outputDepositDir" in {
-    val bagId = UUID.randomUUID()
-    val depositId = "ruimtereis01"
-    stagingDir(depositId).copyTo(outputDepositDir(bagId))
-    outputDepositDir(bagId).toJava should exist
-
-    inside(action.checkOutputDirectoryExists(bagId, depositId)) {
       case Failure(ActionException(msg, _)) => msg should include(s"The deposit for dataset $depositId already exists")
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.multideposit.actions
 
+import java.util.UUID
+
 import better.files.File
 import better.files.File.currentWorkingDirectory
 import javax.naming.directory.Attributes
@@ -66,15 +68,17 @@ class ValidatePreconditionsSpec extends TestSupportFixture with BeforeAndAfterEa
   }
 
   "checkPreconditions" should "verify that the deposit does not yet exist in the outputDepositDir" in {
-    action.checkOutputDirectoryExists("ruimtereis01") shouldBe a[Success[_]]
+    val bagId = UUID.randomUUID()
+    action.checkOutputDirectoryExists(bagId, "ruimtereis01") shouldBe a[Success[_]]
   }
 
   it should "fail if the deposit already exists in the outputDepositDir" in {
+    val bagId = UUID.randomUUID()
     val depositId = "ruimtereis01"
-    stagingDir(depositId).copyTo(outputDepositDir(depositId))
-    outputDepositDir(depositId).toJava should exist
+    stagingDir(depositId).copyTo(outputDepositDir(bagId))
+    outputDepositDir(bagId).toJava should exist
 
-    inside(action.checkOutputDirectoryExists(depositId)) {
+    inside(action.checkOutputDirectoryExists(bagId, depositId)) {
       case Failure(ActionException(msg, _)) => msg should include(s"The deposit for dataset $depositId already exists")
     }
   }


### PR DESCRIPTION
fixes EASY-1584

#### When applied it will
* make sure the output directory is the UUID
* add extra logging for report, move and bagIds

@DANS-KNAW/easy for review