### PR TITLE
Improve custom matcher

### DIFF
--- a/src/test/scala/nl.knaw.dans.easy.multideposit/CustomMatchers.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/CustomMatchers.scala
@@ -43,7 +43,7 @@ trait CustomMatchers {
 
     private def prepForTest(n: Node) = XML.loadString(pp.format(n))
 
-    private def pretty(ns: Iterable[Node]) = ns.map(n => XML.loadString(pp.format(n))).mkString("\n")
+    private def pretty(ns: Iterable[Node]) = ns.map(prepForTest).mkString("\n")
 
     override def apply(left: Iterable[Node]): MatchResult = {
       MatchResult(

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/CustomMatchers.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/CustomMatchers.scala
@@ -39,14 +39,17 @@ trait CustomMatchers {
   def containTrimmed(content: String) = new ContentMatcher(content)
 
   class EqualTrimmedMatcher(right: Iterable[Node]) extends Matcher[Iterable[Node]] {
+    private val pp = new PrettyPrinter(160, 2)
+
+    private def prepForTest(n: Node) = XML.loadString(pp.format(n))
+
+    private def pretty(ns: Iterable[Node]) = ns.map(n => XML.loadString(pp.format(n))).mkString("\n")
+
     override def apply(left: Iterable[Node]): MatchResult = {
       MatchResult(
-        left.zip(right).forall { case (l, r) =>
-          val pp = new PrettyPrinter(160, 2)
-          XML.loadString(pp.format(l)) == XML.loadString(pp.format(r))
-        },
-        s"$left did not equal $right",
-        s"$left did equal $right"
+        left.zip(right).forall { case (l, r) => prepForTest(l) == prepForTest(r) },
+        s"${ pretty(left) } was not equal to ${ pretty(right) }",
+        s"${ pretty(left) } was equal to ${ pretty(right) }"
       )
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/CustomMatchers.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/CustomMatchers.scala
@@ -41,15 +41,19 @@ trait CustomMatchers {
   class EqualTrimmedMatcher(right: Iterable[Node]) extends Matcher[Iterable[Node]] {
     private val pp = new PrettyPrinter(160, 2)
 
-    private def prepForTest(n: Node) = XML.loadString(pp.format(n))
-
-    private def pretty(ns: Iterable[Node]) = ns.map(prepForTest).mkString("\n")
+    private def prepForTest(n: Node): Node = XML.loadString(pp.format(n))
 
     override def apply(left: Iterable[Node]): MatchResult = {
+      val prettyLeft = left.map(prepForTest)
+      val prettyRight = right.map(prepForTest)
+
+      lazy val prettyLeftString = prettyLeft.mkString("\n")
+      lazy val prettyRightString = prettyRight.mkString("\n")
+
       MatchResult(
-        left.zip(right).forall { case (l, r) => prepForTest(l) == prepForTest(r) },
-        s"${ pretty(left) } was not equal to ${ pretty(right) }",
-        s"${ pretty(left) } was equal to ${ pretty(right) }"
+        prettyLeft == prettyRight,
+        s"$prettyLeftString was not equal to $prettyRightString",
+        s"$prettyLeftString was equal to $prettyRightString"
       )
     }
   }


### PR DESCRIPTION
#### When applied it will
* make sure failing tests that compare XML documents will show a `<click to see difference>` in IntelliJ

This PR basically originated from the [comment](https://github.com/DANS-KNAW/easy-deposit-api/pull/54#discussion_r195697089) by @jo-pol, complaining that IntelliJ doesn't provide the mentioned link in custom matchers.

@DANS-KNAW/easy for review