### PR TITLE
EASY-1673: fix NullPointerException in --identifier-info cmd argument

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/CommandLineOptions.scala
@@ -59,7 +59,7 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
     short = 'i',
     descr = "CSV file in which information about the created deposits is reported",
     default = Some(Paths.get(Properties.userHome).resolve(s"easy-split-multi-deposit-identifier-info-$now.csv"))
-  ).map(path => path.toAbsolutePath)
+  ).map(_.toAbsolutePath)
 
   val validateOnly: ScallopOption[Boolean] = opt[Boolean](
     name = "validate",

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/CommandLineOptions.scala
@@ -59,7 +59,7 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
     short = 'i',
     descr = "CSV file in which information about the created deposits is reported",
     default = Some(Paths.get(Properties.userHome).resolve(s"easy-split-multi-deposit-identifier-info-$now.csv"))
-  )
+  ).map(path => path.toAbsolutePath)
 
   val validateOnly: ScallopOption[Boolean] = opt[Boolean](
     name = "validate",

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
@@ -73,7 +73,7 @@ class SplitMultiDepositApp(formats: Set[String], ldap: Ldap, permissions: Deposi
       }
       _ = logger.info("deposits were created successfully")
       _ <- reportDatasets.report(deposits)
-      _ = logger.info("report generated")
+      _ = logger.info(s"report generated at ${paths.reportFile}")
       _ <- deposits.mapUntilFailure(deposit => moveDeposit.moveDepositsToOutputDir(deposit.depositId, deposit.bagId))
       _ = logger.info(s"deposits were successfully moved to ${ output.outputDepositDir }")
     } yield ()


### PR DESCRIPTION
fixes EASY-1673

#### When applied it will
* fix a `NullPointerException` with the `--identifier-info` cmd argument
    * basically what happened was that when `-i ids.csv` was given, no `file.getParent` could be calculated, which results in a `null`. This lead to the `NullPointerException`.
* add some more details to the logging, such that the datamanager can easily find the output report

@DANS-KNAW/easy for review