### PR TITLE
EASY-1684 Laat easy-split-multi-deposit ffprobe aanroepen om te controleren of A/V-bestanden corrupt zijn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -168,6 +169,13 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>rpm-maven-plugin</artifactId>
+                        <configuration>
+                            <group>Applications/Archiving</group>
+                            <requires combine.children="append">
+                                <require>ffmpeg</require>
+                                <require>ffmpeg-libs</require>
+                            </requires>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -4,4 +4,4 @@ staging-dir=/var/opt/dans.knaw.nl/tmp/easy-split-multi-deposit-staging
 auth.ldap.url=ldap://localhost
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=ldapadmin
-audio-video.ffprobe=
+audio-video.ffprobe=/usr/bin/ffprobe

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -4,3 +4,4 @@ staging-dir=/var/opt/dans.knaw.nl/tmp/easy-split-multi-deposit-staging
 auth.ldap.url=ldap://localhost
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=ldapadmin
+audio-video.ffprobe=

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/Command.scala
@@ -19,7 +19,7 @@ import better.files.File
 import nl.knaw.dans.easy.multideposit.PathExplorer.PathExplorers
 import nl.knaw.dans.easy.multideposit.actions.{ InvalidDatamanagerException, InvalidInputException }
 import nl.knaw.dans.easy.multideposit.parser.{ EmptyInstructionsFileException, ParserFailedException }
-import nl.knaw.dans.lib.error.TryExtensions
+import nl.knaw.dans.lib.error.{ CompositeException, TryExtensions }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import resource.managed
 
@@ -42,7 +42,8 @@ object Command extends App with DebugEnhancedLogging {
       case ParserFailedException(_, _) |
            EmptyInstructionsFileException(_) |
            InvalidDatamanagerException(_) |
-           InvalidInputException(_, _) => // do nothing
+           InvalidInputException(_, _) |
+           CompositeException(_) => // do nothing
       case e => logger.error(e.getMessage, e)
     }
     .doIfFailure { case NonFatal(e) => println(s"FAILED: ${ e.getMessage }") }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/FfprobeRunner.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/FfprobeRunner.scala
@@ -19,6 +19,7 @@ import java.io.ByteArrayOutputStream
 
 import better.files.File
 import nl.knaw.dans.easy.multideposit.actions.FfprobeErrorException
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.io.IOUtils
 
 import scala.util.{ Failure, Success, Try }
@@ -58,7 +59,7 @@ trait FfprobeRunner {
   }
 }
 
-object FfprobeRunner {
+object FfprobeRunner extends DebugEnhancedLogging{
 
   def apply(exe: File): FfprobeRunner = new FfprobeRunner {
     require(exe exists, "Cannot create ExeRunner for executable that does not exist")

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/FfprobeRunner.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/FfprobeRunner.scala
@@ -29,8 +29,6 @@ import scala.language.postfixOps
 /**
  * Simple runner for ffprobe. The constructor will fail if the executable does not exist or the current user
  * has no execute permissions.
- *
- * @param ffprobeExe the ffprobe executable to run.
  */
 trait FfprobeRunner {
   val ffprobeExe: File
@@ -61,9 +59,13 @@ trait FfprobeRunner {
 
 object FfprobeRunner extends DebugEnhancedLogging{
 
+  /**
+   * Constructs an FfprobeRunner
+   *
+   * @param exe absolute path of the ffprobe executable
+   * @return
+   */
   def apply(exe: File): FfprobeRunner = new FfprobeRunner {
-    require(exe exists, "Cannot create ExeRunner for executable that does not exist")
-    require(exe isExecutable, "Program is not executable")
     override val ffprobeExe: File = exe
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/FfprobeRunner.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/FfprobeRunner.scala
@@ -1,0 +1,45 @@
+package nl.knaw.dans.easy.multideposit
+
+import java.io.ByteArrayOutputStream
+
+import better.files.File
+import nl.knaw.dans.easy.multideposit.actions.FfprobeErrorException
+import org.apache.commons.io.IOUtils
+
+import scala.util.{ Failure, Success, Try }
+import scala.sys.process.{ ProcessIO, _ }
+import scala.language.postfixOps
+
+/**
+ * Simple runner for ffprobe. The constructor will fail if the executable does not exist or the current user
+ * has no execute permissions.
+ *
+ * @param ffprobeExe the ffprobe executable to run.
+ */
+class FfprobeRunner(ffprobeExe: File) {
+  require(ffprobeExe exists, "Cannot create ExeRunner for executable that does not exist")
+  require(ffprobeExe isExecutable, "Program is not executable")
+
+  /**
+   * Runs ffprobe on a given file. If a non-zero exit value is returned from the ffprobe process, a [[FfprobeErrorException]] is
+   * returned, which details the exit code and the standard error contents.
+   *
+   * @param target the target to probe
+   * @return the result of the call
+   */
+  def run(target: File): Try[Unit] = {
+    val err = new ByteArrayOutputStream()
+    Try {
+      /*
+       * We are ignoring the STDOUT, as we are not interested in the output on successful execution. Note, by the way that
+       * ffprobe returns its messages on the STDERR on successful execution as well!
+       */
+      val proc = Seq(ffprobeExe.toString(), target.toString) run new ProcessIO(_.close(), _ => (), IOUtils.copy(_, err))
+      proc.exitValue
+    }.flatMap {
+      exit =>
+        if (exit == 0) Success(())
+        else Failure(FfprobeErrorException(target, exit, err.toString))
+    }
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/FfprobeRunner.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/FfprobeRunner.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.multideposit
 
 import java.io.ByteArrayOutputStream
@@ -16,12 +31,11 @@ import scala.language.postfixOps
  *
  * @param ffprobeExe the ffprobe executable to run.
  */
-class FfprobeRunner(ffprobeExe: File) {
-  require(ffprobeExe exists, "Cannot create ExeRunner for executable that does not exist")
-  require(ffprobeExe isExecutable, "Program is not executable")
+trait FfprobeRunner {
+  val ffprobeExe: File
 
   /**
-   * Runs ffprobe on a given file. If a non-zero exit value is returned from the ffprobe process, a [[FfprobeErrorException]] is
+   * Runs ffprobe on a given file. If a non-zero exit value is returned from the ffprobe process, a [[nl.knaw.dans.easy.multideposit.actions.FfprobeErrorException]] is
    * returned, which details the exit code and the standard error contents.
    *
    * @param target the target to probe
@@ -41,5 +55,14 @@ class FfprobeRunner(ffprobeExe: File) {
         if (exit == 0) Success(())
         else Failure(FfprobeErrorException(target, exit, err.toString))
     }
+  }
+}
+
+object FfprobeRunner {
+
+  def apply(exe: File): FfprobeRunner = new FfprobeRunner {
+    require(exe exists, "Cannot create ExeRunner for executable that does not exist")
+    require(exe isExecutable, "Program is not executable")
+    override val ffprobeExe: File = exe
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/FfprobeRunner.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/FfprobeRunner.scala
@@ -53,7 +53,7 @@ trait FfprobeRunner {
     }.flatMap {
       exit =>
         if (exit == 0) Success(())
-        else Failure(FfprobeErrorException(target, exit, err.toString))
+        else Failure(FfprobeErrorException(target, exit, new String(err.toByteArray)))
     }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.multideposit
 
 import java.util.Locale
 
+import better.files.File
 import javax.naming.Context
 import javax.naming.ldap.InitialLdapContext
 import nl.knaw.dans.easy.multideposit.PathExplorer._
@@ -29,8 +30,8 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-class SplitMultiDepositApp(formats: Set[String], ldap: Ldap, permissions: DepositPermissions) extends AutoCloseable with DebugEnhancedLogging {
-  private val validator = new ValidatePreconditions(ldap)
+class SplitMultiDepositApp(formats: Set[String], ldap: Ldap, ffprobe: FfprobeRunner, permissions: DepositPermissions) extends AutoCloseable with DebugEnhancedLogging {
+  private val validator = new ValidatePreconditions(ldap, ffprobe)
   private val datamanager = new RetrieveDatamanager(ldap)
   private val createDirs = new CreateDirectories()
   private val createBag = new AddBagToDeposit()
@@ -117,7 +118,8 @@ object SplitMultiDepositApp {
       permissions = configuration.properties.getString("deposit.permissions.access"),
       group = configuration.properties.getString("deposit.permissions.group")
     )
+    val ffprobe = new FfprobeRunner(File(configuration.properties.getString("audio-video.ffprobe")))
 
-    new SplitMultiDepositApp(configuration.formats, ldap, permissions)
+    new SplitMultiDepositApp(configuration.formats, ldap, ffprobe, permissions)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
@@ -118,7 +118,7 @@ object SplitMultiDepositApp {
       permissions = configuration.properties.getString("deposit.permissions.access"),
       group = configuration.properties.getString("deposit.permissions.group")
     )
-    val ffprobe = new FfprobeRunner(File(configuration.properties.getString("audio-video.ffprobe")))
+    val ffprobe = FfprobeRunner(File(configuration.properties.getString("audio-video.ffprobe")))
 
     new SplitMultiDepositApp(configuration.formats, ldap, ffprobe, permissions)
   }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
@@ -52,9 +52,9 @@ class SplitMultiDepositApp(formats: Set[String], ldap: Ldap, ffprobe: FfprobeRun
 
     for {
       _ <- Try { Locale.setDefault(Locale.US) }
-      deposits <- MultiDepositParser.parse(input.multiDepositDir) // ParserFailedException | NoSuchFileException
-      _ <- deposits.map(validator.validateDeposit).collectResults // CompositeException
-      _ <- datamanager.getDatamanagerEmailaddress(datamanagerId) // InvalidDatamanagerException | ActionException
+      deposits <- MultiDepositParser.parse(input.multiDepositDir)
+      _ <- deposits.map(validator.validateDeposit).collectResults
+      _ <- datamanager.getDatamanagerEmailaddress(datamanagerId)
     } yield deposits
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
@@ -51,9 +51,9 @@ class SplitMultiDepositApp(formats: Set[String], ldap: Ldap, ffprobe: FfprobeRun
 
     for {
       _ <- Try { Locale.setDefault(Locale.US) }
-      deposits <- MultiDepositParser.parse(input.multiDepositDir)
-      _ <- deposits.map(validator.validateDeposit).collectResults
-      _ <- datamanager.getDatamanagerEmailaddress(datamanagerId)
+      deposits <- MultiDepositParser.parse(input.multiDepositDir) // ParserFailedException | NoSuchFileException
+      _ <- deposits.map(validator.validateDeposit).collectResults // CompositeException
+      _ <- datamanager.getDatamanagerEmailaddress(datamanagerId) // InvalidDatamanagerException | ActionException
     } yield deposits
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditions.scala
@@ -38,6 +38,7 @@ class ValidatePreconditions(ldap: Ldap, ffprobe: FfprobeRunner) extends DebugEnh
       _ <- checkSpringFieldDepositHasAVformat(deposit)
       _ <- checkSFColumnsIfDepositContainsAVFiles(deposit)
       _ <- checkEitherVideoOrAudio(deposit)
+      _ <- checkAudioVideoNotCorrupt(deposit)
       _ <- checkDepositorUserId(deposit)
     } yield ()
   }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/package.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.multideposit
 
+import better.files.File
+
 package object actions {
 
   class ActionException(msg: String, cause: Option[Throwable] = None) extends Exception(msg, cause.orNull)
@@ -26,4 +28,5 @@ package object actions {
 
   case class InvalidDatamanagerException(msg: String) extends Exception(msg)
   case class InvalidInputException(row: Int, msg: String) extends Exception(msg)
+  case class FfprobeErrorException(file: File, exitValue: Int, err: String) extends Exception(s"File '$file' could not be probed. Exit value: $exitValue, STDERR: '$err'")
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/package.scala
@@ -35,14 +35,6 @@ package object multideposit {
 
   case class DepositPermissions(permissions: String, group: String)
 
-  /**
-   * An exception caused by the user in some way, for example by passing in erroneous arguments or an invalid
-   * instructions.csv
-   *
-   * @param msg the error message
-   */
-  class UserException(msg: String) extends Exception(msg)
-
   implicit class SeqExtensions[T](val seq: Seq[T]) extends AnyVal {
     def mapUntilFailure[S](f: T => Try[S])(implicit cbf: CanBuildFrom[Seq[T], S, Seq[S]]): Try[Seq[S]] = {
       val bf = cbf()

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/package.scala
@@ -35,6 +35,14 @@ package object multideposit {
 
   case class DepositPermissions(permissions: String, group: String)
 
+  /**
+   * An exception caused by the user in some way, for example by passing in erroneous arguments or an invalid
+   * instructions.csv
+   *
+   * @param msg the error message
+   */
+  class UserException(msg: String) extends Exception(msg)
+
   implicit class SeqExtensions[T](val seq: Seq[T]) extends AnyVal {
     def mapUntilFailure[S](f: T => Try[S])(implicit cbf: CanBuildFrom[Seq[T], S, Seq[S]]): Try[Seq[S]] = {
       val bf = cbf()

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -7,3 +7,4 @@ split-multi-deposit.daemon.http.port=20180
 auth.ldap.url=ldap://test.dans.knaw.nl
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=ldapadmin
+audio-video.ffprobe=/usr/local/bin/ffprobe

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -106,19 +106,20 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       }
     }
 
-    def configureLdapMockBehavior() = {
+    def configureMocksBehavior() = {
       (ldap.query(_: String)(_: Attributes => Attributes)) expects(datamanager, *) returning Success(Seq(createDatamanagerAttributes))
       (ldap.query(_: String)(_: Attributes => Boolean)) expects("user001", *) repeat 4 returning Success(Seq(true))
+      (ffprobe.run(_: File)) expects * anyNumberOfTimes() returning Success(())
     }
 
     it should "succeed validating the multideposit" in {
-      configureLdapMockBehavior()
+      configureMocksBehavior()
       app.validate(paths, datamanager) shouldBe a[Success[_]]
     }
 
     it should "succeed converting the multideposit" in {
       doNotRunOnTravis()
-      configureLdapMockBehavior()
+      configureMocksBehavior()
       app.convert(paths, datamanager) shouldBe a[Success[_]]
     }
 

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -35,9 +35,6 @@ import scala.xml.{ Elem, Node, NodeSeq, XML }
 // Note to developers: this classes uses shared tests as described in
 // http://www.scalatest.org/user_guide/sharing_tests
 class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with CustomMatchers {
-  private class Dummy
-
-
   private val formatsFile: File = currentWorkingDirectory / "src" / "main" / "assembly" / "dist" / "cfg" / "acceptedMediaTypes.txt"
   private val formats =
     if (formatsFile.exists) formatsFile.lines.map(_.trim).toSet
@@ -86,6 +83,7 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
 
   def allfieldsSpec(): Unit = {
     val ldap = mock[Ldap]
+    val ffprobe = mock[FfprobeRunner]
     val datamanager = "easyadmin"
     val paths = new PathExplorers(
       md = allfields,
@@ -93,7 +91,7 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       od = outputDepositDir.createIfNotExists(asDirectory = true, createParents = true),
       report = reportFile
     )
-    val app = new SplitMultiDepositApp(formats, ldap, "", DepositPermissions("rwxrwx---", getFileSystemGroup))
+    val app = new SplitMultiDepositApp(formats, ldap, ffprobe, DepositPermissions("rwxrwx---", getFileSystemGroup))
 
     val expectedOutputDir = File(getClass.getResource("/allfields/output").toURI)
 
@@ -339,7 +337,7 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       od = outputDepositDir.createIfNotExists(asDirectory = true, createParents = true),
       report = reportFile
     )
-    val app = new SplitMultiDepositApp(formats, mock[Ldap], "", DepositPermissions("rwxrwx---", getFileSystemGroup))
+    val app = new SplitMultiDepositApp(formats, mock[Ldap], mock[FfprobeRunner], DepositPermissions("rwxrwx---", getFileSystemGroup))
 
     inside(app.convert(paths, "easyadmin")) {
       case Failure(ParserFailedException(report, _)) =>

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -35,6 +35,8 @@ import scala.xml.{ Elem, Node, NodeSeq, XML }
 // Note to developers: this classes uses shared tests as described in
 // http://www.scalatest.org/user_guide/sharing_tests
 class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with CustomMatchers {
+  private class Dummy
+
 
   private val formatsFile: File = currentWorkingDirectory / "src" / "main" / "assembly" / "dist" / "cfg" / "acceptedMediaTypes.txt"
   private val formats =
@@ -91,7 +93,7 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       od = outputDepositDir.createIfNotExists(asDirectory = true, createParents = true),
       report = reportFile
     )
-    val app = new SplitMultiDepositApp(formats, ldap, DepositPermissions("rwxrwx---", getFileSystemGroup))
+    val app = new SplitMultiDepositApp(formats, ldap, "", DepositPermissions("rwxrwx---", getFileSystemGroup))
 
     val expectedOutputDir = File(getClass.getResource("/allfields/output").toURI)
 
@@ -337,7 +339,7 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       od = outputDepositDir.createIfNotExists(asDirectory = true, createParents = true),
       report = reportFile
     )
-    val app = new SplitMultiDepositApp(formats, mock[Ldap], DepositPermissions("rwxrwx---", getFileSystemGroup))
+    val app = new SplitMultiDepositApp(formats, mock[Ldap], "", DepositPermissions("rwxrwx---", getFileSystemGroup))
 
     inside(app.convert(paths, "easyadmin")) {
       case Failure(ParserFailedException(report, _)) =>

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/TestSupportFixture.scala
@@ -110,6 +110,4 @@ trait TestSupportFixture extends FlatSpec with Matchers with OptionValues with I
       )
     )
   }
-
-  def testInstructions: Seq[Instructions] = Seq(testInstructions1, testInstructions2)
 }

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
@@ -18,8 +18,8 @@ package nl.knaw.dans.easy.multideposit.actions
 import better.files.File
 import better.files.File.currentWorkingDirectory
 import javax.naming.directory.Attributes
-import nl.knaw.dans.easy.multideposit.model.{ AVFileMetadata, Audio, FileAccessRights, Metadata, Springfield, Video }
-import nl.knaw.dans.easy.multideposit.{ Ldap, TestSupportFixture }
+import nl.knaw.dans.easy.multideposit.model.{ Audio, AVFileMetadata, FileAccessRights, Metadata, Springfield, Video }
+import nl.knaw.dans.easy.multideposit.{ FfprobeRunner, Ldap, TestSupportFixture }
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
 
@@ -29,7 +29,8 @@ class ValidatePreconditionsSpec extends TestSupportFixture with BeforeAndAfterEa
 
   private val depositId = "dsId1"
   private val ldapMock: Ldap = mock[Ldap]
-  private val action = new ValidatePreconditions(ldapMock, "")
+  private val ffprobeMock: FfprobeRunner = mock[FfprobeRunner]
+  private val action = new ValidatePreconditions(ldapMock, ffprobeMock)
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
@@ -29,7 +29,7 @@ class ValidatePreconditionsSpec extends TestSupportFixture with BeforeAndAfterEa
 
   private val depositId = "dsId1"
   private val ldapMock: Ldap = mock[Ldap]
-  private val action = new ValidatePreconditions(ldapMock)
+  private val action = new ValidatePreconditions(ldapMock, "")
 
   override def beforeEach(): Unit = {
     super.beforeEach()


### PR DESCRIPTION
Fixes EASY-1684

#### When applied it will
* Add a configuration setting to point to the `ffprobe` executable
* Make ffmpeg a dependency through rpm
* Ensure ffprobe is run on each A/V file and an error is reported if the exit code is non-zero

#### Where should the reviewer @DANS-KNAW/easy start?
`FfprobeRunner`

#### How should this be manually tested?
* On `deasy` run the roles `_easy-servers-init` (after checking out the EASY-1684 PR for easy-dtap) and `easy-split-multi-deposit`
* Run `easy-split-multi-deposit` on a multi-deposit with one or more corrupt video files in it.

#### related pull requests on github
https://github.com/DANS-KNAW/easy-dtap/pull/233

