### PR TITLE
improve multi-deposit-instructions.md description of the user license field

### DIFF
--- a/multi-deposit-instructions.md
+++ b/multi-deposit-instructions.md
@@ -118,7 +118,7 @@ In the latter case an extra `xsi:type` is added to the resulting DDM xml.
 
 #### User license
 `DCT_LICENSE` can be one of the elements listed in the [licenses list](src/main/assembly/dist/cfg/licenses.txt).
-This field can only be used when `DDM_ACCESSRIGHTS` is set to `OPEN_ACCESS`.
+This field must be used when `DDM_ACCESSRIGHTS` is set to `OPEN_ACCESS` and is not accepted when `DDM_ACCESSRIGHTS` is set to any other value.
 
 #### Type
 `DC_TYPE` can only have a value from the set {`Collection`, `Dataset`, `Event`, `Image`, 


### PR DESCRIPTION
no JIRA

#### When applied it will
* accurately state that the user license field is required when and only when DDM_ACCESSRIGHTS is set to OPEN_ACCESS

#### Where should the reviewer @DANS-KNAW/easy start?
