### PR TITLE
EASY-2173: 'origin' kolom voor deposit report

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
@@ -62,7 +62,7 @@ class AddPropertiesToDeposit extends DebugEnhancedLogging {
       "identifier.dans-doi.registered" -> Some("no"),
       "identifier.dans-doi.action" -> Some("create"),
       "bag-store.bag-name" ->  Some(bagDirName),
-      "deposit.source" ->  Some("SMD"),
+      "deposit.origin" ->  Some("SMD"),
 
     )
 

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
@@ -62,6 +62,7 @@ class AddPropertiesToDeposit extends DebugEnhancedLogging {
       "identifier.dans-doi.registered" -> Some("no"),
       "identifier.dans-doi.action" -> Some("create"),
       "bag-store.bag-name" ->  Some(bagDirName),
+      "deposit.source" ->  Some("SMD"),
 
     )
 

--- a/src/test/resources/allfields/output/input-ruimtereis01/deposit.properties
+++ b/src/test/resources/allfields/output/input-ruimtereis01/deposit.properties
@@ -16,4 +16,4 @@ state.label=SUBMITTED
 identifier.dans-doi.registered=no
 identifier.dans-doi.action=create
 bag-store.bag-name=bag
-deposit.source=SMD
+deposit.origin=SMD

--- a/src/test/resources/allfields/output/input-ruimtereis01/deposit.properties
+++ b/src/test/resources/allfields/output/input-ruimtereis01/deposit.properties
@@ -16,3 +16,4 @@ state.label=SUBMITTED
 identifier.dans-doi.registered=no
 identifier.dans-doi.action=create
 bag-store.bag-name=bag
+deposit.source=SMD

--- a/src/test/resources/allfields/output/input-ruimtereis02/deposit.properties
+++ b/src/test/resources/allfields/output/input-ruimtereis02/deposit.properties
@@ -12,3 +12,4 @@ state.label=SUBMITTED
 identifier.dans-doi.registered=no
 identifier.dans-doi.action=create
 bag-store.bag-name=bag
+deposit.source=SMD

--- a/src/test/resources/allfields/output/input-ruimtereis02/deposit.properties
+++ b/src/test/resources/allfields/output/input-ruimtereis02/deposit.properties
@@ -12,4 +12,4 @@ state.label=SUBMITTED
 identifier.dans-doi.registered=no
 identifier.dans-doi.action=create
 bag-store.bag-name=bag
-deposit.source=SMD
+deposit.origin=SMD

--- a/src/test/resources/allfields/output/input-ruimtereis03/deposit.properties
+++ b/src/test/resources/allfields/output/input-ruimtereis03/deposit.properties
@@ -12,3 +12,4 @@ state.label=SUBMITTED
 identifier.dans-doi.registered=no
 identifier.dans-doi.action=create
 bag-store.bag-name=bag
+deposit.source=SMD

--- a/src/test/resources/allfields/output/input-ruimtereis03/deposit.properties
+++ b/src/test/resources/allfields/output/input-ruimtereis03/deposit.properties
@@ -12,4 +12,4 @@ state.label=SUBMITTED
 identifier.dans-doi.registered=no
 identifier.dans-doi.action=create
 bag-store.bag-name=bag
-deposit.source=SMD
+deposit.origin=SMD

--- a/src/test/resources/allfields/output/input-ruimtereis04/deposit.properties
+++ b/src/test/resources/allfields/output/input-ruimtereis04/deposit.properties
@@ -16,4 +16,4 @@ state.label=SUBMITTED
 identifier.dans-doi.registered=no
 identifier.dans-doi.action=create
 bag-store.bag-name=bag
-deposit.source=SMD
+deposit.origin=SMD

--- a/src/test/resources/allfields/output/input-ruimtereis04/deposit.properties
+++ b/src/test/resources/allfields/output/input-ruimtereis04/deposit.properties
@@ -16,3 +16,4 @@ state.label=SUBMITTED
 identifier.dans-doi.registered=no
 identifier.dans-doi.action=create
 bag-store.bag-name=bag
+deposit.source=SMD

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -64,7 +64,7 @@ class AddPropertiesToDepositSpec extends TestSupportFixture with BeforeAndAfterE
         "identifier.dans-doi.registered",
         "identifier.dans-doi.action",
         "bag-store.bag-name",
-        "deposit.source",
+        "deposit.origin",
       ) and contain noneOf(
         "springfield.domain",
         "springfield.user",
@@ -81,7 +81,7 @@ class AddPropertiesToDepositSpec extends TestSupportFixture with BeforeAndAfterE
     resultProps.getString("curation.performed") shouldBe "yes"
     resultProps.getString("identifier.dans-doi.registered") shouldBe "no"
     resultProps.getString("identifier.dans-doi.action") shouldBe "create"
-    resultProps.getString("deposit.source") shouldBe "SMD"
+    resultProps.getString("deposit.origin") shouldBe "SMD"
   }
 
   it should "generate the properties file with springfield fields and write the properties in it" in {
@@ -115,7 +115,7 @@ class AddPropertiesToDepositSpec extends TestSupportFixture with BeforeAndAfterE
         "identifier.dans-doi.registered",
         "identifier.dans-doi.action",
         "bag-store.bag-name",
-        "deposit.source",
+        "deposit.origin",
       )
     }
 
@@ -132,6 +132,6 @@ class AddPropertiesToDepositSpec extends TestSupportFixture with BeforeAndAfterE
     resultProps.getString("identifier.dans-doi.registered") shouldBe "no"
     resultProps.getString("identifier.dans-doi.action") shouldBe "create"
     resultProps.getString("bag-store.bag-name") shouldBe bagDirName
-    resultProps.getString("deposit.source") shouldBe "SMD"
+    resultProps.getString("deposit.origin") shouldBe "SMD"
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -64,6 +64,7 @@ class AddPropertiesToDepositSpec extends TestSupportFixture with BeforeAndAfterE
         "identifier.dans-doi.registered",
         "identifier.dans-doi.action",
         "bag-store.bag-name",
+        "deposit.source",
       ) and contain noneOf(
         "springfield.domain",
         "springfield.user",
@@ -80,6 +81,7 @@ class AddPropertiesToDepositSpec extends TestSupportFixture with BeforeAndAfterE
     resultProps.getString("curation.performed") shouldBe "yes"
     resultProps.getString("identifier.dans-doi.registered") shouldBe "no"
     resultProps.getString("identifier.dans-doi.action") shouldBe "create"
+    resultProps.getString("deposit.source") shouldBe "SMD"
   }
 
   it should "generate the properties file with springfield fields and write the properties in it" in {
@@ -113,6 +115,7 @@ class AddPropertiesToDepositSpec extends TestSupportFixture with BeforeAndAfterE
         "identifier.dans-doi.registered",
         "identifier.dans-doi.action",
         "bag-store.bag-name",
+        "deposit.source",
       )
     }
 
@@ -129,5 +132,6 @@ class AddPropertiesToDepositSpec extends TestSupportFixture with BeforeAndAfterE
     resultProps.getString("identifier.dans-doi.registered") shouldBe "no"
     resultProps.getString("identifier.dans-doi.action") shouldBe "create"
     resultProps.getString("bag-store.bag-name") shouldBe bagDirName
+    resultProps.getString("deposit.source") shouldBe "SMD"
   }
 }


### PR DESCRIPTION
Fixes EASY-2173

#### When applied it will
* add new property `deposit.source` to deposit properties
* gives this property value `SMD`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-manage-deposit                      | [PR#54](https://github.com/DANS-KNAW/easy-manage-deposit/pull/54)     | ..
easy-sword2                      | [PR#132](https://github.com/DANS-KNAW/easy-sword2/pull/132)     | ..
easy-deposit-api                      | [PR#166](https://github.com/DANS-KNAW/easy-deposit-api/pull/166)     | ..
easy-specs                     | [PR#82](https://github.com/DANS-KNAW/easy-specs/pull/82)     | ..

