### PR TITLE
NO-JIRA: better row numbering for FileDescriptor

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.multideposit/model/FileMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/model/FileMetadata.scala
@@ -38,6 +38,7 @@ case class AVFileMetadata(override val filepath: File,
                           subtitles: Set[SubtitlesFile] = Set.empty
                          ) extends FileMetadata(filepath, mimeType)
 
-case class FileDescriptor(title: Option[String] = Option.empty,
+case class FileDescriptor(rowNum: Int,
+                          title: Option[String] = Option.empty,
                           accessibility: Option[FileAccessRights.Value] = Option.empty,
                           visibility: Option[FileAccessRights.Value] = Option.empty)

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/parser/FileDescriptorParser.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/parser/FileDescriptorParser.scala
@@ -33,7 +33,7 @@ trait FileDescriptorParser {
       .fold(_.invalid, combineFileDescriptors(rowNum))
   }
 
-  def fileDescriptor(depositId: DepositId)(row: DepositRow): Option[Validated[(File, Option[String], Option[FileAccessRights], Option[FileAccessRights])]] = {
+  def fileDescriptor(depositId: DepositId)(row: DepositRow): Option[Validated[(Int, File, Option[String], Option[FileAccessRights], Option[FileAccessRights])]] = {
     val path = row.find("FILE_PATH").map(findRegularFile(depositId, row.rowNum))
     val title = row.find("FILE_TITLE")
     val accessibility = row.find("FILE_ACCESSIBILITY").map(fileAccessibility(row.rowNum))
@@ -52,6 +52,7 @@ trait FileDescriptorParser {
           .some
       case (Some(p), t, a, v) =>
         (
+          row.rowNum.toValidated,
           p,
           t.toValidated,
           a.sequence,
@@ -60,15 +61,15 @@ trait FileDescriptorParser {
     }
   }
 
-  private def combineFileDescriptors(rowNum: Int)(descriptors: List[(File, Option[String], Option[FileAccessRights], Option[FileAccessRights])]): Validated[Map[File, FileDescriptor]] = {
-    descriptors.groupBy { case (file, _, _, _) => file }
+  private def combineFileDescriptors(rowNum: Int)(descriptors: List[(Int, File, Option[String], Option[FileAccessRights], Option[FileAccessRights])]): Validated[Map[File, FileDescriptor]] = {
+    descriptors.groupBy { case (_, file, _, _, _) => file }
       .map((toFileDescriptor(rowNum) _).tupled)
       .toList
       .sequence
       .map(_.toMap)
   }
 
-  private def ensureAtMostOneElementInList[T](list: List[T])(err: List[T] => ParseError): Validated[Option[T]] = {
+  private def checkAtMostOneElementInList[T](list: List[T])(err: List[T] => ParseError): Validated[Option[T]] = {
     list match {
       case Nil => none.toValidated
       case title :: Nil => title.some.toValidated
@@ -76,15 +77,16 @@ trait FileDescriptorParser {
     }
   }
 
-  private def toFileDescriptor(rowNum: => Int)(file: File, dataPerPath: List[(File, Option[String], Option[FileAccessRights], Option[FileAccessRights])]): Validated[(File, FileDescriptor)] = {
+  private def toFileDescriptor(rowNum: => Int)(file: File, dataPerPath: List[(Int, File, Option[String], Option[FileAccessRights], Option[FileAccessRights])]): Validated[(File, FileDescriptor)] = {
     (
-      ensureAtMostOneElementInList(dataPerPath.collect { case (_, Some(title), _, _) => title })(titles => ParseError(rowNum, s"FILE_TITLE defined multiple values for file '$file': ${ titles.mkString("[", ", ", "]") }")),
-      ensureAtMostOneElementInList(dataPerPath.collect { case (_, _, Some(far), _) => far })(fileAccessibilities => ParseError(rowNum, s"FILE_ACCESSIBILITY defined multiple values for file '$file': ${ fileAccessibilities.mkString("[", ", ", "]") }")),
-      ensureAtMostOneElementInList(dataPerPath.collect { case (_, _, _, Some(fv)) => fv })(fileVisibilities => ParseError(rowNum, s"FILE_VISIBILITY defined multiple values for file '$file': ${ fileVisibilities.mkString("[", ", ", "]") }")),
+      dataPerPath.collect { case (localRowNum, _, _, _, _) => localRowNum }.min.toValidated,
+      checkAtMostOneElementInList(dataPerPath.collect { case (_, _, Some(title), _, _) => title })(titles => ParseError(rowNum, s"FILE_TITLE defined multiple values for file '$file': ${ titles.mkString("[", ", ", "]") }")),
+      checkAtMostOneElementInList(dataPerPath.collect { case (_, _, _, Some(far), _) => far })(fileAccessibilities => ParseError(rowNum, s"FILE_ACCESSIBILITY defined multiple values for file '$file': ${ fileAccessibilities.mkString("[", ", ", "]") }")),
+      checkAtMostOneElementInList(dataPerPath.collect { case (_, _, _, _, Some(fv)) => fv })(fileVisibilities => ParseError(rowNum, s"FILE_VISIBILITY defined multiple values for file '$file': ${ fileVisibilities.mkString("[", ", ", "]") }")),
     ).mapN(FileDescriptor)
       .map((file, _))
       .andThen {
-        case (_, FileDescriptor(_, Some(as), Some(vs))) if vs > as => ParseError(rowNum, s"FILE_VISIBILITY ($vs) is more restricted than FILE_ACCESSIBILITY ($as) for file '$file'. (User will potentially have access to an invisible file.)").toInvalid
+        case (_, FileDescriptor(localRowNum, _, Some(as), Some(vs))) if vs > as => ParseError(localRowNum, s"FILE_VISIBILITY ($vs) is more restricted than FILE_ACCESSIBILITY ($as) for file '$file'. (User will potentially have access to an invisible file.)").toInvalid
         case otherwise => otherwise.toValidated
       }
   }

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/TestSupportFixture.scala
@@ -83,8 +83,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with OptionValues with E
         rightsholder = NonEmptyList.one("Mr. Anderson"),
       ),
       files = Map(
-        testDir / "md/ruimtereis01/reisverslag/centaur.mpg" -> FileDescriptor(Option("flyby of centaur")),
-        testDir / "md/ruimtereis01/path/to/a/random/video/hubble.mpg" -> FileDescriptor(Option("video about the hubble space telescope")),
+        testDir / "md/ruimtereis01/reisverslag/centaur.mpg" -> FileDescriptor(2, Option("flyby of centaur")),
+        testDir / "md/ruimtereis01/path/to/a/random/video/hubble.mpg" -> FileDescriptor(3, Option("video about the hubble space telescope")),
       ),
       audioVideo = AudioVideo(
         springfield = Option(Springfield("dans", "janvanmansum", "Jans-test-files", PlayMode.Menu)),
@@ -122,7 +122,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with OptionValues with E
         rightsholder = NonEmptyList.of("Neo"),
       ),
       files = Map(
-        testDir / "md/ruimtereis02/path/to/images/Hubble_01.jpg" -> FileDescriptor(Some("Hubble"), Some(FileAccessRights.RESTRICTED_REQUEST))
+        testDir / "md/ruimtereis02/path/to/images/Hubble_01.jpg" -> FileDescriptor(5, Some("Hubble"), Some(FileAccessRights.RESTRICTED_REQUEST))
       )
     )
   }

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/parser/FileDescriptorParserSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/parser/FileDescriptorParserSpec.scala
@@ -46,11 +46,13 @@ trait FileDescriptorTestObjects {
   lazy val fileDescriptors: Map[File, FileDescriptor] = Map(
     multiDepositDir / "ruimtereis01/reisverslag/centaur.mpg" ->
       FileDescriptor(
+        rowNum = 2,
         title = Option("video about the centaur meteorite"),
         accessibility = Option(FileAccessRights.RESTRICTED_GROUP)
       ),
     multiDepositDir / "ruimtereis01/path/to/a/random/video/hubble.mpg" ->
       FileDescriptor(
+        rowNum = 3,
         title = Option.empty,
         accessibility = Option(FileAccessRights.RESTRICTED_GROUP)
       )
@@ -89,7 +91,7 @@ class FileDescriptorParserSpec extends TestSupportFixture with FileDescriptorTes
 
     extractFileDescriptors("ruimtereis01", 2, row1 :: row2 :: Nil).value should {
       have size 1 and contain only
-        file -> FileDescriptor(Some("some title"), Some(FileAccessRights.KNOWN))
+        file -> FileDescriptor(2, Some("some title"), Some(FileAccessRights.KNOWN))
     }
   }
 
@@ -108,7 +110,7 @@ class FileDescriptorParserSpec extends TestSupportFixture with FileDescriptorTes
     val file = multiDepositDir / "ruimtereis01/reisverslag/centaur.mpg"
 
     extractFileDescriptors("ruimtereis01", 2, row1 :: row2 :: Nil).value should {
-      have size 1 and contain only file -> FileDescriptor()
+      have size 1 and contain only file -> FileDescriptor(2)
     }
   }
 
@@ -123,7 +125,7 @@ class FileDescriptorParserSpec extends TestSupportFixture with FileDescriptorTes
 
     extractFileDescriptors("ruimtereis01", 2, row :: Nil).value should {
       have size 1 and contain only
-        file -> FileDescriptor(Some("some title"), None)
+        file -> FileDescriptor(2, Some("some title"), None)
     }
   }
 
@@ -138,7 +140,7 @@ class FileDescriptorParserSpec extends TestSupportFixture with FileDescriptorTes
 
     extractFileDescriptors("ruimtereis01", 2, row :: Nil).value should {
       have size 1 and contain only
-        file -> FileDescriptor(accessibility = Some(FileAccessRights.KNOWN))
+        file -> FileDescriptor(2, accessibility = Some(FileAccessRights.KNOWN))
     }
   }
 
@@ -199,15 +201,20 @@ class FileDescriptorParserSpec extends TestSupportFixture with FileDescriptorTes
   }
 
   it should "fail if visibility is more restricted than accessibility" in {
-    val row = DepositRow(2, Map(
+    val row1 = DepositRow(2, Map(
+      "FILE_PATH" -> "path/to/a/random/video/hubble.mpg",
+      "FILE_VISIBILITY" -> "NONE",
+      "FILE_ACCESSIBILITY" -> "NONE"
+    ))
+    val row2 = DepositRow(3, Map(
       "FILE_PATH" -> "reisverslag/centaur.mpg",
       "FILE_VISIBILITY" -> "NONE",
       "FILE_ACCESSIBILITY" -> "KNOWN"
     ))
 
     val file = multiDepositDir / "ruimtereis01/reisverslag/centaur.mpg"
-    extractFileDescriptors("ruimtereis01", 2, row :: Nil).invalidValue shouldBe
-      ParseError(2, s"FILE_VISIBILITY (NONE) is more restricted than FILE_ACCESSIBILITY (KNOWN) for file '$file'. (User will potentially have access to an invisible file.)").chained
+    extractFileDescriptors("ruimtereis01", 2, row1 :: row2 :: Nil).invalidValue shouldBe
+      ParseError(3, s"FILE_VISIBILITY (NONE) is more restricted than FILE_ACCESSIBILITY (KNOWN) for file '$file'. (User will potentially have access to an invisible file.)").chained
   }
 
   it should "succeed if visibility is equally restricted as accessibility" in {
@@ -219,7 +226,7 @@ class FileDescriptorParserSpec extends TestSupportFixture with FileDescriptorTes
 
     val file = multiDepositDir / "ruimtereis01/reisverslag/centaur.mpg"
     val expectedOutput = Map(
-      file -> FileDescriptor(none, FileAccessRights.NONE.some, FileAccessRights.NONE.some),
+      file -> FileDescriptor(2, none, FileAccessRights.NONE.some, FileAccessRights.NONE.some),
     )
     extractFileDescriptors("ruimtereis01", 2, row :: Nil).value shouldBe expectedOutput
   }
@@ -232,7 +239,7 @@ class FileDescriptorParserSpec extends TestSupportFixture with FileDescriptorTes
     ))
 
     val file = multiDepositDir / "ruimtereis01/reisverslag/centaur.mpg"
-    fileDescriptor("ruimtereis01")(row).value.value shouldBe (file, Some("some title"), Some(FileAccessRights.KNOWN), None)
+    fileDescriptor("ruimtereis01")(row).value.value shouldBe (2, file, Some("some title"), Some(FileAccessRights.KNOWN), None)
   }
 
   it should "fail if the path does not exist" in {
@@ -265,7 +272,7 @@ class FileDescriptorParserSpec extends TestSupportFixture with FileDescriptorTes
     ))
 
     val file = multiDepositDir / "ruimtereis01/reisverslag/centaur.mpg"
-    fileDescriptor("ruimtereis01")(row).value.value shouldBe (file, Some("some title"), None, None)
+    fileDescriptor("ruimtereis01")(row).value.value shouldBe (2, file, Some("some title"), None, None)
   }
 
   it should "fail if an invalid FILE_ACCESSIBILITY is given" in {

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/parser/FileMetadataParserSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/parser/FileMetadataParserSpec.scala
@@ -160,7 +160,7 @@ class FileMetadataParserSpec extends TestSupportFixture with FileMetadataTestObj
   it should "fail when the deposit contains A/V files, Springfield PlayMode is Menu, and a FileTitle is not present" in {
     val fileWithNoDescription = testDir / "md/ruimtereis01/path/to/a/random/video/hubble.mpg"
     val instructions = testInstructions1.copy(
-      files = testInstructions1.files.updated(fileWithNoDescription, FileDescriptor(title = Option.empty)),
+      files = testInstructions1.files.updated(fileWithNoDescription, FileDescriptor(3, title = Option.empty)),
     )
 
     extractFileMetadata(multiDepositDir / "ruimtereis01", instructions).invalidValue shouldBe
@@ -182,8 +182,8 @@ class FileMetadataParserSpec extends TestSupportFixture with FileMetadataTestObj
     val file2 = testDir / "md/ruimtereis01/path/to/a/random/video/hubble.mpg"
     val instructions = testInstructions1.copy(
       files = testInstructions1.files
-        .updated(file1, FileDescriptor(Option.empty))
-        .updated(file2, FileDescriptor(Option.empty))
+        .updated(file1, FileDescriptor(2, Option.empty))
+        .updated(file2, FileDescriptor(3, Option.empty))
     )
 
     extractFileMetadata(multiDepositDir / "ruimtereis01", instructions).invalidValue.toNonEmptyList.toList should contain only(

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/parser/MultiDepositParserSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/parser/MultiDepositParserSpec.scala
@@ -327,7 +327,7 @@ class MultiDepositParserSpec extends TestSupportFixture with DepositTestObjects 
 
   it should "succeed if there are multiple depositorUserIDs that are all equal" in {
     val rows = DepositRow(2, depositCSVRow1) ::
-      DepositRow(2, depositCSVRow2 + ("DEPOSITOR_ID" -> "ikke")) ::
+      DepositRow(3, depositCSVRow2 + ("DEPOSITOR_ID" -> "ikke")) ::
       Nil
 
     extractInstructions("ruimtereis01", 2, rows).value shouldBe instructions


### PR DESCRIPTION
Use the exact row number instead of the first row number of the deposit in `instructions.csv` in an error message for the `FileDescriptor`.

@DANS-KNAW/easy for review