### PR TITLE
EASY-2332: validation of UUIDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.pathikrit</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/parser/MultiDepositParser.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/parser/MultiDepositParser.scala
@@ -175,7 +175,8 @@ trait MultiDepositParser extends ParserUtils with InputPathExplorer
   }
 
   def uuid(rowNum: => Int, columnName: => String)(s: String): Validated[Option[UUID]] = {
-    catchOnly[IllegalArgumentException] { Option(UUID.fromString(s)) }
+    s.toUUID
+      .map(Option(_))
       .leftMap(_ => ParseError(rowNum, s"$columnName value '$s' does not conform to the UUID format"))
       .toValidatedNec
   }


### PR DESCRIPTION
Fixes EASY-2332

#### When applied it will
* validate `UUIDs` using `dans.lib.string.toUUID` method

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-archive-bag   | [PR#66](https://github.com/DANS-KNAW/easy-archive-bag/pull/66)     | ..
easy-auth-info   | [PR#36](https://github.com/DANS-KNAW/easy-auth-info/pull/36)     | ..
easy-bag-index  | [PR#50](https://github.com/DANS-KNAW/easy-bag-index/pull/50)     | ..
easy-bag-store  | [PR#100](https://github.com/DANS-KNAW/easy-bag-store/pull/100)     | ..
easy-delete-dataset  | [PR#19](https://github.com/DANS-KNAW/easy-delete-dataset/pull/19)     | ..
easy-deposit-api  | [PR#204](https://github.com/DANS-KNAW/easy-deposit-api/pull/204)     | ..
easy-deposit-properties  | [PR#23](https://github.com/DANS-KNAW/easy-deposit-properties/pull/23)     | ..
easy-ingest-flow  | [PR#137](https://github.com/DANS-KNAW/easy-ingest-flow/pull/137)     | ..
easy-solr4files-index  | [PR#54](https://github.com/DANS-KNAW/easy-solr4files-index/pull/54)     | ..
easy-transform-metadata  | [PR#11](https://github.com/DANS-KNAW/easy-transform-metadata/pull/11)     | ..
easy-validate-dans-bag  | [PR#73](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/73)     | ..

