### PR TITLE
EASY-2704: add case sensitive validation for depositorId

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditions.scala
@@ -79,7 +79,7 @@ class ValidatePreconditions(ldap: Ldap, ffprobe: FfprobeRunner) extends DebugEnh
   }
 
   def validateDepositorUserId(row: Int, depositorUserId: DepositorUserId)(attrs: Attributes): FailFast[Unit] = {
-    lazy val existingDepositorId = Option(attrs.get("uid")).exists(attr => attr.get().toString == depositorUserId)
+    val existingDepositorId = Option(attrs.get("uid")).exists(_.get().toString == depositorUserId)
     lazy val activeState = Option(attrs.get("dansState")).exists(_.get().toString == "ACTIVE")
 
     if (existingDepositorId)

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditions.scala
@@ -20,10 +20,11 @@ import cats.data.ValidatedNec
 import cats.instances.list._
 import cats.syntax.either._
 import cats.syntax.traverse._
+import javax.naming.directory.Attributes
 import nl.knaw.dans.easy.multideposit.FfprobeRunner.FfprobeError
 import nl.knaw.dans.easy.multideposit.PathExplorer.StagingPathExplorer
-import nl.knaw.dans.easy.multideposit.model.{ AVFileMetadata, Deposit, DepositId }
 import nl.knaw.dans.easy.multideposit._
+import nl.knaw.dans.easy.multideposit.model.{ AVFileMetadata, Deposit, DepositId, DepositorUserId }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 class ValidatePreconditions(ldap: Ldap, ffprobe: FfprobeRunner) extends DebugEnhancedLogging {
@@ -68,15 +69,22 @@ class ValidatePreconditions(ldap: Ldap, ffprobe: FfprobeRunner) extends DebugEnh
     logger.debug("check that the depositor is an active user")
 
     val depositorUserId = deposit.depositorUserId
-    ldap.query(depositorUserId)(attrs => Option(attrs.get("dansState")).exists(_.get().toString == "ACTIVE"))
+    ldap.query(depositorUserId)(validateDepositorUserId(deposit.row, depositorUserId))
       .flatMap {
         case Seq() => InvalidInput(deposit.row, s"depositorUserId '$depositorUserId' is unknown").asLeft
         case Seq(head) => head.asRight
         case _ => ActionError(s"There appear to be multiple users with id '$depositorUserId'").asLeft
       }
-      .flatMap {
-        case true => ().asRight
-        case false => InvalidInput(deposit.row, s"The depositor '$depositorUserId' is not an active user").asLeft
-      }
+      .flatMap(identity)
+  }
+
+  def validateDepositorUserId(row: Int, depositorUserId: DepositorUserId)(attrs: Attributes): FailFast[Unit] = {
+    lazy val existingDepositorId = Option(attrs.get("uid")).exists(attr => attr.get().toString == depositorUserId)
+    lazy val activeState = Option(attrs.get("dansState")).exists(_.get().toString == "ACTIVE")
+
+    if (existingDepositorId)
+      if (activeState) ().asRight
+      else InvalidInput(row, s"The depositor '$depositorUserId' is not an active user").asLeft
+    else InvalidInput(row, "The depositor does not exist. Please check for spelling mistakes and upper/lowercase letters").asLeft
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -19,6 +19,7 @@ import java.util.UUID
 
 import better.files.File
 import better.files.File.currentWorkingDirectory
+import cats.syntax.either._
 import javax.naming.directory.{ Attributes, BasicAttribute, BasicAttributes }
 import nl.knaw.dans.easy.multideposit.PathExplorer.PathExplorers
 import org.apache.commons.configuration.PropertiesConfiguration
@@ -107,7 +108,7 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
 
     def configureMocksBehavior() = {
       (ldap.query(_: String)(_: Attributes => Attributes)) expects(datamanager, *) returning Right(Seq(createDatamanagerAttributes))
-      (ldap.query(_: String)(_: Attributes => Boolean)) expects("user001", *) repeat 4 returning Right(Seq(true))
+      (ldap.query(_: String)(_: Attributes => FailFast[Unit])) expects("user001", *) repeat 4 returning Right(Seq(().asRight))
       (ffprobe.run(_: File)) expects * anyNumberOfTimes() returning Right(())
     }
 

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
@@ -109,12 +109,12 @@ class ValidatePreconditionsSpec extends TestSupportFixture with BeforeAndAfterEa
     val depositorId = "user001"
 
     val attrs: Attributes = mock[Attributes]
-    val attr1: Attribute = mock[Attribute]
-    val attr2: Attribute = mock[Attribute]
-    attrs.get _ expects "uid" once() returning attr1
-    attrs.get _ expects "dansState" once() returning attr2
-    (() => attr1.get()) expects() once() returning depositorId
-    (() => attr2.get()) expects() once() returning "ACTIVE"
+    val uidAttr: Attribute = mock[Attribute]
+    val dansStateAttr: Attribute = mock[Attribute]
+    attrs.get _ expects "uid" once() returning uidAttr
+    attrs.get _ expects "dansState" once() returning dansStateAttr
+    (() => uidAttr.get()) expects() once() returning depositorId
+    (() => dansStateAttr.get()) expects() once() returning "ACTIVE"
 
     action.validateDepositorUserId(2, depositorId)(attrs) shouldBe right[Unit]
   }
@@ -123,10 +123,10 @@ class ValidatePreconditionsSpec extends TestSupportFixture with BeforeAndAfterEa
     val depositorId = "UseR001"
 
     val attrs: Attributes = mock[Attributes]
-    val attr1: Attribute = mock[Attribute]
-    attrs.get _ expects "uid" once() returning attr1
+    val uidAttr: Attribute = mock[Attribute]
+    attrs.get _ expects "uid" once() returning uidAttr
     attrs.get _ expects "dansState" never()
-    (() => attr1.get()) expects() once() returning depositorId
+    (() => uidAttr.get()) expects() once() returning depositorId
 
     action.validateDepositorUserId(2, depositorId.toLowerCase)(attrs).leftValue.msg shouldBe "row 2: The depositor does not exist. Please check for spelling mistakes and upper/lowercase letters"
   }
@@ -135,12 +135,12 @@ class ValidatePreconditionsSpec extends TestSupportFixture with BeforeAndAfterEa
     val depositorId = "user001"
 
     val attrs: Attributes = mock[Attributes]
-    val attr1: Attribute = mock[Attribute]
-    val attr2: Attribute = mock[Attribute]
-    attrs.get _ expects "uid" once() returning attr1
-    attrs.get _ expects "dansState" once() returning attr2
-    (() => attr1.get()) expects() once() returning depositorId
-    (() => attr2.get()) expects() once() returning "BLOCKED"
+    val uidAttr: Attribute = mock[Attribute]
+    val dansStateAttr: Attribute = mock[Attribute]
+    attrs.get _ expects "uid" once() returning uidAttr
+    attrs.get _ expects "dansState" once() returning dansStateAttr
+    (() => uidAttr.get()) expects() once() returning depositorId
+    (() => dansStateAttr.get()) expects() once() returning "BLOCKED"
 
     action.validateDepositorUserId(2, depositorId)(attrs).leftValue.msg shouldBe s"row 2: The depositor '$depositorId' is not an active user"
   }
@@ -158,10 +158,10 @@ class ValidatePreconditionsSpec extends TestSupportFixture with BeforeAndAfterEa
     val depositorId = "user001"
 
     val attrs: Attributes = mock[Attributes]
-    val attr1: Attribute = mock[Attribute]
-    attrs.get _ expects "uid" once() returning attr1
+    val uidAttr: Attribute = mock[Attribute]
+    attrs.get _ expects "uid" once() returning uidAttr
     attrs.get _ expects "dansState" once() returning null
-    (() => attr1.get()) expects() once() returning depositorId
+    (() => uidAttr.get()) expects() once() returning depositorId
 
     action.validateDepositorUserId(2, depositorId)(attrs).leftValue.msg shouldBe s"row 2: The depositor '$depositorId' is not an active user"
   }

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
@@ -128,7 +128,7 @@ class ValidatePreconditionsSpec extends TestSupportFixture with BeforeAndAfterEa
     attrs.get _ expects "dansState" never()
     (() => uidAttr.get()) expects() once() returning depositorId
 
-    action.validateDepositorUserId(2, depositorId.toLowerCase)(attrs).leftValue.msg shouldBe "row 2: The depositor does not exist. Please check for spelling mistakes and upper/lowercase letters"
+    action.validateDepositorUserId(2, depositorId.toLowerCase)(attrs).leftValue.msg shouldBe "row 2: Depositor 'user001' does not exist in LDAP. We've found 'UseR001', which is slightly different. Please check for upper/lowercase spelling mistakes."
   }
 
   it should "return false if the uid is equal to the given depositorUserId and the state is not 'ACTIVE'" in {
@@ -151,7 +151,7 @@ class ValidatePreconditionsSpec extends TestSupportFixture with BeforeAndAfterEa
     val attrs: Attributes = mock[Attributes]
     attrs.get _ expects "uid" once() returning null
 
-    action.validateDepositorUserId(2, depositorId)(attrs).leftValue.msg shouldBe "row 2: The depositor does not exist. Please check for spelling mistakes and upper/lowercase letters"
+    action.validateDepositorUserId(2, depositorId)(attrs).leftValue.msg shouldBe "row 2: Depositor 'user001' does not exist in LDAP."
   }
 
   it should "return false if the 'uid' parameter is found in the given Attribute, but 'dansState' is not" in {

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/ValidatePreconditionsSpec.scala
@@ -16,7 +16,8 @@
 package nl.knaw.dans.easy.multideposit.actions
 
 import better.files.File
-import javax.naming.directory.Attributes
+import cats.syntax.either._
+import javax.naming.directory.{ Attribute, Attributes }
 import nl.knaw.dans.easy.multideposit.FfprobeRunner.FfprobeError
 import nl.knaw.dans.easy.multideposit._
 import nl.knaw.dans.easy.multideposit.model.{ AVFileMetadata, FileAccessRights, Video }
@@ -73,18 +74,18 @@ class ValidatePreconditionsSpec extends TestSupportFixture with BeforeAndAfterEa
       visibleTo = FileAccessRights.ANONYMOUS
     ))
 
-  def mockLdapForDepositor(expectedResult: Seq[Boolean]): Unit = {
-    (ldapMock.query(_: String)(_: Attributes => Boolean)) expects("dp1", *) returning Right(expectedResult)
+  def mockLdapForDepositor(expectedResult: Seq[FailFast[Unit]]): Unit = {
+    (ldapMock.query(_: String)(_: Attributes => FailFast[Unit])) expects("dp1", *) returning Right(expectedResult)
   }
 
   "checkDepositorUserId" should "succeed if ldap identifies the depositorUserId as active" in {
-    mockLdapForDepositor(Seq(true))
+    mockLdapForDepositor(Seq(().asRight))
 
     action.checkDepositorUserId(testInstructions1.copy(depositorUserId = "dp1").toDeposit()) shouldBe right[Unit]
   }
 
   it should "fail if ldap identifies the depositorUserId as not active" in {
-    mockLdapForDepositor(Seq(false))
+    mockLdapForDepositor(Seq(InvalidInput(2, "depositor 'dp1' is not an active user").asLeft))
 
     action.checkDepositorUserId(testInstructions1.copy(depositorUserId = "dp1").toDeposit())
       .leftValue.msg should include("depositor 'dp1' is not an active user")
@@ -98,10 +99,71 @@ class ValidatePreconditionsSpec extends TestSupportFixture with BeforeAndAfterEa
   }
 
   it should "fail if ldap returns multiple values" in {
-    mockLdapForDepositor(Seq(true, true))
+    mockLdapForDepositor(Seq(().asRight, ().asRight))
 
     action.checkDepositorUserId(testInstructions1.copy(depositorUserId = "dp1").toDeposit())
       .leftValue.msg should include("multiple users with id 'dp1'")
+  }
+
+  "validateDepositorUserId" should "return true if the uid is equal to the given depositorUserId and the state is 'ACTIVE'" in {
+    val depositorId = "user001"
+
+    val attrs: Attributes = mock[Attributes]
+    val attr1: Attribute = mock[Attribute]
+    val attr2: Attribute = mock[Attribute]
+    attrs.get _ expects "uid" once() returning attr1
+    attrs.get _ expects "dansState" once() returning attr2
+    (() => attr1.get()) expects() once() returning depositorId
+    (() => attr2.get()) expects() once() returning "ACTIVE"
+
+    action.validateDepositorUserId(2, depositorId)(attrs) shouldBe right[Unit]
+  }
+
+  it should "return false if the uid is not case sensitive equal to the given depositorUserId" in {
+    val depositorId = "UseR001"
+
+    val attrs: Attributes = mock[Attributes]
+    val attr1: Attribute = mock[Attribute]
+    attrs.get _ expects "uid" once() returning attr1
+    attrs.get _ expects "dansState" never()
+    (() => attr1.get()) expects() once() returning depositorId
+
+    action.validateDepositorUserId(2, depositorId.toLowerCase)(attrs).leftValue.msg shouldBe "row 2: The depositor does not exist. Please check for spelling mistakes and upper/lowercase letters"
+  }
+
+  it should "return false if the uid is equal to the given depositorUserId and the state is not 'ACTIVE'" in {
+    val depositorId = "user001"
+
+    val attrs: Attributes = mock[Attributes]
+    val attr1: Attribute = mock[Attribute]
+    val attr2: Attribute = mock[Attribute]
+    attrs.get _ expects "uid" once() returning attr1
+    attrs.get _ expects "dansState" once() returning attr2
+    (() => attr1.get()) expects() once() returning depositorId
+    (() => attr2.get()) expects() once() returning "BLOCKED"
+
+    action.validateDepositorUserId(2, depositorId)(attrs).leftValue.msg shouldBe s"row 2: The depositor '$depositorId' is not an active user"
+  }
+
+  it should "return false if the 'uid' parameter is not found in the given Attribute" in {
+    val depositorId = "user001"
+
+    val attrs: Attributes = mock[Attributes]
+    attrs.get _ expects "uid" once() returning null
+
+    action.validateDepositorUserId(2, depositorId)(attrs).leftValue.msg shouldBe "row 2: The depositor does not exist. Please check for spelling mistakes and upper/lowercase letters"
+  }
+
+  it should "return false if the 'uid' parameter is found in the given Attribute, but 'dansState' is not" in {
+    val depositorId = "user001"
+
+    val attrs: Attributes = mock[Attributes]
+    val attr1: Attribute = mock[Attribute]
+    attrs.get _ expects "uid" once() returning attr1
+    attrs.get _ expects "dansState" once() returning null
+    (() => attr1.get()) expects() once() returning depositorId
+
+    action.validateDepositorUserId(2, depositorId)(attrs).leftValue.msg shouldBe s"row 2: The depositor '$depositorId' is not an active user"
   }
 
   def mockFfprobeRunnerForAllSuccess(): Unit = {


### PR DESCRIPTION
fixes EASY-2704

#### When applied it will
* add case sensitive validation for depositorId

@DANS-KNAW/easy for review