### PR TITLE
EASY-1842: easy-split-multi-deposit moet AV_SUBTITLES_LANGUAGE vereisen als AV_SUBTITLES opgegeven is

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.multideposit/parser/AudioVideoParser.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/parser/AudioVideoParser.scala
@@ -118,7 +118,7 @@ trait AudioVideoParser {
           p.isRegularFile &&
           sub.exists &&
           sub.isRegularFile &&
-          subLang.forall(isValidISO639_1Language) =>
+          subLang.exists(isValidISO639_1Language) =>
         (p, SubtitlesFile(sub, subLang)).toValidated.some
       case (Some(Valid(p)), Some(_), _)
         if !p.exists =>
@@ -135,6 +135,8 @@ trait AudioVideoParser {
       case (Some(_), Some(_), Some(subLang))
         if !isValidISO639_1Language(subLang) =>
         ParseError(row.rowNum, s"${ Headers.AudioVideoSubtitlesLanguage } '$subLang' doesn't have a valid ISO 639-1 language value").toInvalid.some
+      case (Some(_), Some(_), None) =>
+        ParseError(row.rowNum, s"${ Headers.AudioVideoSubtitlesLanguage } AV_SUBTITLES specified without AV_SUBTITLES_LANGUAGE").toInvalid.some
       case (Some(_), None, Some(subLang)) =>
         ParseError(row.rowNum, s"Missing value for ${ Headers.AudioVideoSubtitles }, since ${ Headers.AudioVideoSubtitlesLanguage } does have a value: '$subLang'").toInvalid.some
       case (Some(Valid(p)), None, None)

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/parser/AudioVideoParserSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/parser/AudioVideoParserSpec.scala
@@ -553,16 +553,15 @@ class AudioVideoParserSpec extends TestSupportFixture with AudioVideoTestObjects
       ParseError(2, "Missing value for AV_SUBTITLES, since AV_SUBTITLES_LANGUAGE does have a value: 'en'").chained
   }
 
-  it should "succeed if there is a value for AV_SUBTITLES, but no value for AV_SUBTITLES_LANGUAGE" in {
+  it should "fail if there is a value for AV_SUBTITLES, but no value for AV_SUBTITLES_LANGUAGE" in {
     val row = DepositRow(2, Map(
       Headers.AudioVideoFilePath -> "reisverslag/centaur.mpg",
       Headers.AudioVideoSubtitles -> "reisverslag/centaur.srt",
       Headers.AudioVideoSubtitlesLanguage -> ""
     ))
 
-    val file = multiDepositDir / "ruimtereis01" / "reisverslag" / "centaur.mpg"
-    val subtitles = SubtitlesFile(multiDepositDir / "ruimtereis01" / "reisverslag" / "centaur.srt")
-    avFile("ruimtereis01")(row).value.value shouldBe(`file`, `subtitles`)
+    avFile("ruimtereis01")(row).value.invalidValue shouldBe
+      ParseError(2, "AV_SUBTITLES_LANGUAGE AV_SUBTITLES specified without AV_SUBTITLES_LANGUAGE").chained
   }
 
   it should "succeed if there is no value for both AV_SUBTITLES and AV_SUBTITLES_LANGUAGE" in {


### PR DESCRIPTION
fixes EASY-1842

#### When applied it will
* give an error message when there is `subtitles` file given but no `subtitles language`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
