### PR TITLE
EASY-2423: easy-split-multi-deposit: A/V-bestandsnamen mogen geen spaties bevatten

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.multideposit/parser/ParserValidation.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/parser/ParserValidation.scala
@@ -98,14 +98,14 @@ trait ParserValidation extends DebugEnhancedLogging {
   def checkAllAVFileNamesWithoutSpaces(deposit: Deposit): Validated[Unit] = {
     deposit.files.collect { case fmd: AVFileMetadata => fmd.filepath.name }
       .toList
-      .traverse(name => noSpaces(deposit.row, name))
+      .traverse(noSpaces(deposit.row))
       .map(_ => ())
   }
 
-  private def noSpaces(row: Int, s: String): Validated[String] = {
-    if (!s.contains(' '))
-      s.toValidated
-    else
+  private def noSpaces(row: Int)(s: String): Validated[String] = {
+    if (s.contains(' '))
       ParseError(row, s"A/V filename '$s' contains spaces").toInvalid
+    else
+      s.toValidated
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/parser/ParserValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/parser/ParserValidationSpec.scala
@@ -57,6 +57,17 @@ class ParserValidationSpec extends TestSupportFixture with BeforeAndAfterEach wi
     )
   )
 
+  private val avFileReferences2 = Seq(
+    AVFileMetadata(
+      filepath = testDir / "md" / "ruimtereis01" / "reisverslag" / "big centaur.mpg",
+      mimeType = "video/mpeg",
+      vocabulary = Video,
+      title = "flyby of centaur",
+      accessibleTo = FileAccessRights.ANONYMOUS,
+      visibleTo = FileAccessRights.ANONYMOUS
+    )
+  )
+
   "checkUserLicenseOnlyWithOpenAccess" should "succeed when accessright=OPEN_ACCESS and user license is given" in {
     val baseDeposit = testInstructions1.toDeposit()
     val deposit = baseDeposit.copy(
@@ -230,5 +241,22 @@ class ParserValidationSpec extends TestSupportFixture with BeforeAndAfterEach wi
 
     validation.checkAllAVFilesHaveSameAccessibility(deposit) shouldBe
       ParseError(2, "Multiple accessibility levels found for A/V files: {ANONYMOUS, RESTRICTED_REQUEST}").toInvalid
+  }
+
+  "checkAllAVFileNamesWithoutSpaces" should "succeed when there are no spaces in A/V filenames" in {
+    val deposit = testInstructions1.toDeposit(avFileReferences).copy(
+      depositId = depositId,
+      springfield = Option(Springfield("domain", "user", "collection", PlayMode.Continuous))
+    )
+    validation.checkAllAVFileNamesWithoutSpaces(deposit).isValid shouldBe true
+  }
+
+  it should "fail when there are spaces in A/V filenames" in {
+    val deposit = testInstructions1.toDeposit(avFileReferences2).copy(
+      depositId = depositId,
+      springfield = Option(Springfield("domain", "user", "collection", PlayMode.Continuous))
+    )
+    validation.checkAllAVFileNamesWithoutSpaces(deposit) shouldBe
+      ParseError(2, "A/V filename 'big centaur.mpg' contains spaces").toInvalid
   }
 }


### PR DESCRIPTION
fixes EASY-2423

#### When applied it will
* Check that `A/V filenames` don’t contain `spaces`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
