### PR TITLE
EASY-2390: SMD: Zet dans-doi-action op 'update' als DOI en BASE-REVISION zijn gegeven

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -5,4 +5,4 @@ auth.ldap.url=ldap://localhost
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=changeme
 audio-video.ffprobe=/usr/bin/ffprobe
-dans.doi=10.17026/
+dans.doi.prefix=10.17026/

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -5,3 +5,4 @@ auth.ldap.url=ldap://localhost
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=changeme
 audio-video.ffprobe=/usr/bin/ffprobe
+dans.doi=10.17026/

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
@@ -28,8 +28,8 @@ import nl.knaw.dans.easy.multideposit.model.Datamanager
 import nl.knaw.dans.easy.multideposit.parser.MultiDepositParser
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
-class SplitMultiDepositApp(formats: Set[String], userLicenses: Set[String], ldap: Ldap, ffprobe: FfprobeRunner, permissions: DepositPermissions, dansDoi: String) extends AutoCloseable with DebugEnhancedLogging {
-  private val createMultiDeposit = new CreateMultiDeposit(formats, ldap, ffprobe, permissions, dansDoi)
+class SplitMultiDepositApp(formats: Set[String], userLicenses: Set[String], ldap: Ldap, ffprobe: FfprobeRunner, permissions: DepositPermissions, dansDoiPrefix: String) extends AutoCloseable with DebugEnhancedLogging {
+  private val createMultiDeposit = new CreateMultiDeposit(formats, ldap, ffprobe, permissions, dansDoiPrefix)
 
   override def close(): Unit = ldap.close()
 
@@ -90,8 +90,8 @@ object SplitMultiDepositApp {
       require(exeFile.isExecutable, s"Ffprobe at $exeFile is not executable")
       FfprobeRunner(exeFile)
     }
-    val dansDoi = configuration.properties.getString("dans.doi")
+    val dansDoiPrefix = configuration.properties.getString("dans.doi.prefix")
 
-    new SplitMultiDepositApp(configuration.formats, configuration.licenses, ldap, ffprobe, permissions, dansDoi)
+    new SplitMultiDepositApp(configuration.formats, configuration.licenses, ldap, ffprobe, permissions, dansDoiPrefix)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositApp.scala
@@ -28,8 +28,8 @@ import nl.knaw.dans.easy.multideposit.model.Datamanager
 import nl.knaw.dans.easy.multideposit.parser.MultiDepositParser
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
-class SplitMultiDepositApp(formats: Set[String], userLicenses: Set[String], ldap: Ldap, ffprobe: FfprobeRunner, permissions: DepositPermissions) extends AutoCloseable with DebugEnhancedLogging {
-  private val createMultiDeposit = new CreateMultiDeposit(formats, ldap, ffprobe, permissions)
+class SplitMultiDepositApp(formats: Set[String], userLicenses: Set[String], ldap: Ldap, ffprobe: FfprobeRunner, permissions: DepositPermissions, dansDoi: String) extends AutoCloseable with DebugEnhancedLogging {
+  private val createMultiDeposit = new CreateMultiDeposit(formats, ldap, ffprobe, permissions, dansDoi)
 
   override def close(): Unit = ldap.close()
 
@@ -90,7 +90,8 @@ object SplitMultiDepositApp {
       require(exeFile.isExecutable, s"Ffprobe at $exeFile is not executable")
       FfprobeRunner(exeFile)
     }
+    val dansDoi = configuration.properties.getString("dans.doi")
 
-    new SplitMultiDepositApp(configuration.formats, configuration.licenses, ldap, ffprobe, permissions)
+    new SplitMultiDepositApp(configuration.formats, configuration.licenses, ldap, ffprobe, permissions, dansDoi)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
@@ -22,7 +22,7 @@ import nl.knaw.dans.easy.multideposit.{ ActionError, FailFast, now }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 
-class AddPropertiesToDeposit extends DebugEnhancedLogging {
+class AddPropertiesToDeposit(dansDoi: String) extends DebugEnhancedLogging {
 
   def addDepositProperties(deposit: Deposit, datamanagerId: Datamanager, emailaddress: DatamanagerEmailaddress)(implicit stage: StagingPathExplorer): FailFast[Unit] = {
     logger.debug(s"add deposit properties for ${ deposit.depositId }")
@@ -40,6 +40,7 @@ class AddPropertiesToDeposit extends DebugEnhancedLogging {
   }
 
   private def addProperties(deposit: Deposit, datamanagerId: Datamanager, emailaddress: DatamanagerEmailaddress, bagDirName: String)(properties: PropertiesConfiguration): Unit = {
+    val doiAction = if (deposit.baseUUID.isDefined && hasDansDoi(deposit)) "update" else "create"
     val sf = deposit.springfield
     val props: Map[String, Option[String]] = Map(
       "bag-store.bag-id" -> Some(deposit.bagId.toString),
@@ -56,7 +57,7 @@ class AddPropertiesToDeposit extends DebugEnhancedLogging {
       "springfield.collection" -> sf.map(_.collection),
       "springfield.playmode" -> sf.map(_.playMode.toString),
       "identifier.dans-doi.registered" -> Some("no"),
-      "identifier.dans-doi.action" -> Some("create"),
+      "identifier.dans-doi.action" -> Some(doiAction),
       "bag-store.bag-name" -> Some(bagDirName),
       "deposit.origin" -> Some("SMD"),
     )
@@ -64,5 +65,14 @@ class AddPropertiesToDeposit extends DebugEnhancedLogging {
     for ((key, value) <- props.collect { case (k, Some(v)) => (k, v) }) {
       properties.setProperty(key, value)
     }
+  }
+
+  private def hasDansDoi(deposit: Deposit): Boolean = {
+    var exists = false
+    for (identifier <- deposit.metadata.identifiers) {
+      if (identifier.id.startsWith(dansDoi))
+        exists = true
+    }
+    exists
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDeposit.scala
@@ -22,7 +22,7 @@ import nl.knaw.dans.easy.multideposit.{ ActionError, FailFast, now }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 
-class AddPropertiesToDeposit(dansDoi: String) extends DebugEnhancedLogging {
+class AddPropertiesToDeposit(dansDoiPrefix: String) extends DebugEnhancedLogging {
 
   def addDepositProperties(deposit: Deposit, datamanagerId: Datamanager, emailaddress: DatamanagerEmailaddress)(implicit stage: StagingPathExplorer): FailFast[Unit] = {
     logger.debug(s"add deposit properties for ${ deposit.depositId }")
@@ -40,7 +40,7 @@ class AddPropertiesToDeposit(dansDoi: String) extends DebugEnhancedLogging {
   }
 
   private def addProperties(deposit: Deposit, datamanagerId: Datamanager, emailaddress: DatamanagerEmailaddress, bagDirName: String)(properties: PropertiesConfiguration): Unit = {
-    val doiAction = if (deposit.baseUUID.isDefined && hasDansDoi(deposit)) "update" else "create"
+    val doiAction = if (deposit.baseUUID.isDefined && hasDansDoiPrefix(deposit)) "update" else "create"
     val sf = deposit.springfield
     val props: Map[String, Option[String]] = Map(
       "bag-store.bag-id" -> Some(deposit.bagId.toString),
@@ -67,10 +67,10 @@ class AddPropertiesToDeposit(dansDoi: String) extends DebugEnhancedLogging {
     }
   }
 
-  private def hasDansDoi(deposit: Deposit): Boolean = {
+  private def hasDansDoiPrefix(deposit: Deposit): Boolean = {
     var exists = false
     for (identifier <- deposit.metadata.identifiers) {
-      if (identifier.id.startsWith(dansDoi))
+      if (identifier.id.startsWith(dansDoiPrefix))
         exists = true
     }
     exists

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/CreateMultiDeposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/CreateMultiDeposit.scala
@@ -29,7 +29,7 @@ class CreateMultiDeposit(formats: Set[String],
                          ldap: Ldap,
                          ffprobe: FfprobeRunner,
                          permissions: DepositPermissions,
-                         dansDoi:String) extends DebugEnhancedLogging {
+                         dansDoiPrefix:String) extends DebugEnhancedLogging {
 
   private val validator = new ValidatePreconditions(ldap, ffprobe)
   private val datamanager = new RetrieveDatamanager(ldap)
@@ -37,7 +37,7 @@ class CreateMultiDeposit(formats: Set[String],
   private val createBag = new AddBagToDeposit()
   private val datasetMetadata = new AddDatasetMetadataToDeposit(formats)
   private val fileMetadata = new AddFileMetadataToDeposit()
-  private val depositProperties = new AddPropertiesToDeposit(dansDoi)
+  private val depositProperties = new AddPropertiesToDeposit(dansDoiPrefix)
   private val setPermissions = new SetDepositPermissions(permissions)
   private val reportDatasets = new ReportDatasets()
   private val moveDeposit = new MoveDepositToOutputDir()

--- a/src/main/scala/nl.knaw.dans.easy.multideposit/actions/CreateMultiDeposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.multideposit/actions/CreateMultiDeposit.scala
@@ -28,7 +28,8 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 class CreateMultiDeposit(formats: Set[String],
                          ldap: Ldap,
                          ffprobe: FfprobeRunner,
-                         permissions: DepositPermissions) extends DebugEnhancedLogging {
+                         permissions: DepositPermissions,
+                         dansDoi:String) extends DebugEnhancedLogging {
 
   private val validator = new ValidatePreconditions(ldap, ffprobe)
   private val datamanager = new RetrieveDatamanager(ldap)
@@ -36,7 +37,7 @@ class CreateMultiDeposit(formats: Set[String],
   private val createBag = new AddBagToDeposit()
   private val datasetMetadata = new AddDatasetMetadataToDeposit(formats)
   private val fileMetadata = new AddFileMetadataToDeposit()
-  private val depositProperties = new AddPropertiesToDeposit()
+  private val depositProperties = new AddPropertiesToDeposit(dansDoi)
   private val setPermissions = new SetDepositPermissions(permissions)
   private val reportDatasets = new ReportDatasets()
   private val moveDeposit = new MoveDepositToOutputDir()

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -91,8 +91,8 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       od = outputDepositDir.createIfNotExists(asDirectory = true, createParents = true),
       report = reportFile
     )
-    val dansDoi = "10.17026/"
-    val app = new SplitMultiDepositApp(formats, userLicenses, ldap, ffprobe, DepositPermissions("rwxrwx---", getFileSystemGroup), dansDoi)
+    val dansDoiPrefix = "10.17026/"
+    val app = new SplitMultiDepositApp(formats, userLicenses, ldap, ffprobe, DepositPermissions("rwxrwx---", getFileSystemGroup), dansDoiPrefix)
 
     val expectedOutputDir = File(getClass.getResource("/allfields/output").toURI)
 
@@ -341,8 +341,8 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       od = outputDepositDir.createIfNotExists(asDirectory = true, createParents = true),
       report = reportFile
     )
-    val dansDoi = "10.17026/"
-    val app = new SplitMultiDepositApp(formats, userLicenses, mock[Ldap], mock[FfprobeRunner], DepositPermissions("rwxrwx---", getFileSystemGroup), dansDoi)
+    val dansDoiPrefix = "10.17026/"
+    val app = new SplitMultiDepositApp(formats, userLicenses, mock[Ldap], mock[FfprobeRunner], DepositPermissions("rwxrwx---", getFileSystemGroup), dansDoiPrefix)
 
     inside(app.convert(paths, "easyadmin").leftValue.toNonEmptyList.toList) {
       case List(ParseFailed(report)) =>

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/SplitMultiDepositAppSpec.scala
@@ -91,7 +91,8 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       od = outputDepositDir.createIfNotExists(asDirectory = true, createParents = true),
       report = reportFile
     )
-    val app = new SplitMultiDepositApp(formats, userLicenses, ldap, ffprobe, DepositPermissions("rwxrwx---", getFileSystemGroup))
+    val dansDoi = "10.17026/"
+    val app = new SplitMultiDepositApp(formats, userLicenses, ldap, ffprobe, DepositPermissions("rwxrwx---", getFileSystemGroup), dansDoi)
 
     val expectedOutputDir = File(getClass.getResource("/allfields/output").toURI)
 
@@ -340,7 +341,8 @@ class SplitMultiDepositAppSpec extends TestSupportFixture with MockFactory with 
       od = outputDepositDir.createIfNotExists(asDirectory = true, createParents = true),
       report = reportFile
     )
-    val app = new SplitMultiDepositApp(formats, userLicenses, mock[Ldap], mock[FfprobeRunner], DepositPermissions("rwxrwx---", getFileSystemGroup))
+    val dansDoi = "10.17026/"
+    val app = new SplitMultiDepositApp(formats, userLicenses, mock[Ldap], mock[FfprobeRunner], DepositPermissions("rwxrwx---", getFileSystemGroup), dansDoi)
 
     inside(app.convert(paths, "easyadmin").leftValue.toNonEmptyList.toList) {
       case List(ParseFailed(report)) =>

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/TestSupportFixture.scala
@@ -120,7 +120,7 @@ trait TestSupportFixture extends AnyFlatSpec with Matchers with OptionValues wit
         subjects = List(Subject("subject 1", Option("abr:ABRcomplex")), Subject("subject 2"), Subject("subject 3")),
         publishers = List("publisher 1"),
         types = NonEmptyList.of(DcType.STILLIMAGE),
-        identifiers = List(Identifier("id1234")),
+        identifiers = List(Identifier("10.17026/abcdef12345")),
         rightsholder = NonEmptyList.of("Neo"),
       ),
       files = Map(

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -29,8 +29,8 @@ class AddPropertiesToDepositSpec extends TestSupportFixture with BeforeAndAfterE
   private val depositId = "ds1"
   private val datamanagerId = "dm"
   private val datamanagerEmail = "dm@test.org"
-  private val dansDoi = "10.17026/"
-  private val action = new AddPropertiesToDeposit(dansDoi)
+  private val dansDoiPrefix = "10.17026/"
+  private val action = new AddPropertiesToDeposit(dansDoiPrefix)
 
   override def beforeEach(): Unit = {
     val path = stagingDir / s"sd-$depositId"

--- a/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDepositSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.multideposit/actions/AddPropertiesToDepositSpec.scala
@@ -29,7 +29,8 @@ class AddPropertiesToDepositSpec extends TestSupportFixture with BeforeAndAfterE
   private val depositId = "ds1"
   private val datamanagerId = "dm"
   private val datamanagerEmail = "dm@test.org"
-  private val action = new AddPropertiesToDeposit
+  private val dansDoi = "10.17026/"
+  private val action = new AddPropertiesToDeposit(dansDoi)
 
   override def beforeEach(): Unit = {
     val path = stagingDir / s"sd-$depositId"
@@ -80,6 +81,52 @@ class AddPropertiesToDepositSpec extends TestSupportFixture with BeforeAndAfterE
     resultProps.getString("curation.performed") shouldBe "yes"
     resultProps.getString("identifier.dans-doi.registered") shouldBe "no"
     resultProps.getString("identifier.dans-doi.action") shouldBe "create"
+    resultProps.getString("deposit.origin") shouldBe "SMD"
+  }
+
+  it should "generate the properties file and write the properties in it with dans-doi.action 'update'" in {
+    val uuid = UUID.randomUUID()
+    action.addDepositProperties(testInstructions2.copy(audioVideo = AudioVideo()).toDeposit().copy(bagId = uuid), datamanagerId, datamanagerEmail) shouldBe right[Unit]
+
+    val props = stagingPropertiesFile(testInstructions2.depositId)
+    props.toJava should exist
+
+    val resultProps = new PropertiesConfiguration {
+      setDelimiterParsingDisabled(true)
+      load(props.toJava)
+    }
+
+    resultProps.getKeys.asScala.toList should {
+      contain only(
+        "bag-store.bag-id",
+        "creation.timestamp",
+        "state.label",
+        "state.description",
+        "depositor.userId",
+        "curation.datamanager.email",
+        "curation.datamanager.userId",
+        "curation.required",
+        "curation.performed",
+        "identifier.dans-doi.registered",
+        "identifier.dans-doi.action",
+        "bag-store.bag-name",
+        "deposit.origin",
+      ) and contain noneOf(
+        "springfield.domain",
+        "springfield.user",
+        "springfield.collection",
+        "springfield.playmode",
+      )
+    }
+
+    resultProps.getString("bag-store.bag-id") shouldBe uuid.toString
+    resultProps.getString("depositor.userId") shouldBe "ruimtereiziger2"
+    resultProps.getString("curation.datamanager.email") shouldBe datamanagerEmail
+    resultProps.getString("curation.datamanager.userId") shouldBe datamanagerId
+    resultProps.getString("curation.required") shouldBe "yes"
+    resultProps.getString("curation.performed") shouldBe "yes"
+    resultProps.getString("identifier.dans-doi.registered") shouldBe "no"
+    resultProps.getString("identifier.dans-doi.action") shouldBe "update"
     resultProps.getString("deposit.origin") shouldBe "SMD"
   }
 


### PR DESCRIPTION
fixes EASY-2390

#### When applied it will
* set `dans-doi-action` to '`update`' when the deposit has a `base-revision` and a `DANS Doi.`
 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-dtap                      | [PR#480](https://github.com/DANS-KNAW/easy-dtap/pull/480) 
